### PR TITLE
Revert "Correct French typo"

### DIFF
--- a/sportstracker/src/main/resources/i18n/SportsTracker_fr.properties
+++ b/sportstracker/src/main/resources/i18n/SportsTracker_fr.properties
@@ -26,18 +26,18 @@ st.intensity.maximum=maximum
 st.intensity.intervals=fractionn\u00E9s
 
 # SportsTracker main class
-st.main.error.create_dir=Impossible de cr\u00E9er le r\u00E9pertoire de donn\u00E9es, vous ne pourrez pas sauvegarder vos donn\u00E9es\u00A0!\nPour plus d\u02B9information, consultez les messages dans la console.
-st.main.error.load_data=Impossible de charger les donn\u00E9es\u00A0! D\u00E9marrage \u00E0 partir de listes vides.\nPour plus d\u02B9informations, consultez les messages dans la console.
-st.main.error.missing_exercise_files=Les fichiers d\u02B9exercice suivants ne peuvent pas \u00EAtre trouv\u00E9s\u00A0: \n\n%s\nS\u02B9il vous plait, Contr\u00F4ler manuellement vos fichiers.
-st.main.error.save_data=Impossible de sauvegarder les donn\u00E9es\u00A0!\nPour plus d\u02B9informations, consultez les messages dans la console.
+st.main.error.create_dir=Impossible de cr\u00E9er le r\u00E9pertoire de donn\u00E9es, vous ne pourrez pas sauvegarder vos donn\u00E9es!\nPour plus d\u02B9information, consultez les messages dans la console.
+st.main.error.load_data=Impossible de charger les donn\u00E9es! D\u00E9marrage \u00E0 partir de listes vides.\nPour plus d\u02B9informations, consultez les messages dans la console.
+st.main.error.missing_exercise_files=Les fichiers d\u02B9exercice suivants ne peuvent pas \u00EAtre trouv\u00E9s: \n\n%s\nS\u02B9il vous plait, Contr\u00F4ler manuellement vos fichiers.
+st.main.error.save_data=Impossible de sauvegarder les donn\u00E9es!\nPour plus d\u02B9informations, consultez les messages dans la console.
 st.main.confirm.save_exit.title=Enregistrer les modifications
-st.main.confirm.save_exit.text=Voulez-vous enregistrer vos modifications\u00A0?
+st.main.confirm.save_exit.text=Voulez-vous enregistrer vos modifications?
 st.main.info.initial_sporttypes_added=Plusieurs cat\u00E9gories de sport ont \u00E9t\u00E9 ajout\u00E9es par d\u00E9faut, vous pouvez les \u00E9diter.
-st.main.error.no_sporttype=Vous devez cr\u00E9er au moins une cat\u00E9gorie sportive\u00A0!
-st.main.error.no_exercise=Vous devez cr\u00E9er au moins un exercice\u00A0!
-st.main.error.no_note=Vous devez cr\u00E9er au moins une premi\u00E8re note\u00A0!
-st.main.error.no_weight=Vous devez cr\u00E9er au moins un poids d\u02B9abord\u00A0!
-st.main.error.print_view=Impossible d\u02B9imprimer la vue actuelle\u00A0! Voir les messages d\u02B9erreur\npour plus d\u02B9informations.
+st.main.error.no_sporttype=Vous devez cr\u00E9er au moins une cat\u00E9gorie sportive!
+st.main.error.no_exercise=Vous devez cr\u00E9er au moins un exercice!
+st.main.error.no_note=Vous devez cr\u00E9er au moins une premi\u00E8re note!
+st.main.error.no_weight=Vous devez cr\u00E9er au moins un poids d\u02B9abord!
+st.main.error.print_view=Impossible d\u02B9imprimer la vue actuelle! Voir les messages d\u02B9erreur\npour plus d\u02B9informations.
 st.main.error.print_view.no_printer=Impossible d\u02B9imprimer, il n\u02B9y a pas d\u02B9imprimante d\u02B9install\u00E9e.
 
 # SportsTracker view
@@ -50,18 +50,18 @@ st.view.save.Action.accelerator=CTL+S
 st.view.save.Action.shortDescription=Enregistrer les modifications
 st.view.print.Action.text=Impression
 st.view.print.Action.accelerator=CTL+P
-st.view.print.Action.shortDescription=Imprimer les exercices de la vue actuelle.
+st.view.print.Action.shortDescription=Imprimer les Exercices de la vue actuelle.
 st.view.quit.Action.text=_Quitter
 st.view.quit.Action.accelerator=CTL+Q
 st.view.quit.Action.shortDescription=Quitter SportsTracker
 
 st.view.edit.text=_Editer
-st.view.exercise_add.Action.text=_Ajouter un exercice
-st.view.exercise_add.Action.shortDescription=Ajouter un exercice
+st.view.exercise_add.Action.text=_Ajouter un Exercice
+st.view.exercise_add.Action.shortDescription=Ajouter un Exercice
 st.view.note_add.Action.text=Ajouter une _Note
-st.view.note_add.Action.shortDescription=Ajouter une note
+st.view.note_add.Action.shortDescription=Ajouter une Note
 st.view.weight_add.Action.text=Ajouter un _Poids
-st.view.weight_add.Action.shortDescription=Ajouter un poids
+st.view.weight_add.Action.shortDescription=Ajouter un Poids
 st.view.entry_copy.Action.text=_Copier l\u02B9entr\u00E9e
 st.view.entry_copy.Action.shortDescription=Copier l\u02B9entr\u00E9e
 st.view.entry_delete.Action.text=_Effacer l\u02B9entr\u00E9e
@@ -70,23 +70,23 @@ st.view.entry_edit.Action.text=_Editer l\u02B9entr\u00E9e
 st.view.entry_edit.Action.shortDescription=Editer l\u02B9entr\u00E9e
 st.view.view_hrm.Action.text=_Ouvrir le Fichier HRM
 st.view.view_hrm.Action.accelerator=CTL+H
-st.view.view_hrm.Action.shortDescription=Ouvrir le fichier HRM
+st.view.view_hrm.Action.shortDescription=Ouvrir le Fichier HRM
 st.view.preferences.Action.text=_Pr\u00E9f\u00E9rences
-st.view.preferences.Action.shortDescription=Editer les pr\u00E9f\u00E9rences
+st.view.preferences.Action.shortDescription=Editer les Pr\u00E9f\u00E9rences
 
 st.view.view.text=_Affichage
 st.view.calendar_view.Action.text=_Calendrier
-st.view.calendar_view.Action.shortDescription=Affichage du calendrier
-st.view.exercise_list_view.Action.text=_Listes des exercices
-st.view.exercise_list_view.Action.shortDescription=Affichage de la liste des exercices.
+st.view.calendar_view.Action.shortDescription=Affichage du Calendrier
+st.view.exercise_list_view.Action.text=_Listes des Exercices
+st.view.exercise_list_view.Action.shortDescription=Affichage de la Liste des Exercices.
 st.view.note_list_view.Action.text=Liste des _Notes
-st.view.note_list_view.Action.shortDescription=Afficher la liste des notes
+st.view.note_list_view.Action.shortDescription=Afficher la liste des Notes
 st.view.weight_list_view.Action.text=Liste des Poids
-st.view.weight_list_view.Action.shortDescription=Afficher la liste des poids
+st.view.weight_list_view.Action.shortDescription=Afficher la liste des Poids
 st.view.filter_exercises.Action.text=_Filtre des Exercices
-st.view.filter_exercises.Action.shortDescription=Filtre des exercices
-st.view.filter_disable.Action.text=_D\u00E9sactiver le filtre
-st.view.filter_disable.Action.shortDescription=D\u00E9sactiver le filtre
+st.view.filter_exercises.Action.shortDescription=Filtre des Exercices
+st.view.filter_disable.Action.text=_D\u00E9sactiver le Filtre
+st.view.filter_disable.Action.shortDescription=D\u00E9sactiver le Filtre
 
 st.view.tools.text=_Outils
 st.view.sporttype_editor.Action.text=Editer les cat\u00E9gories sportives
@@ -97,19 +97,19 @@ st.view.overview_diagram.Action.text=_Courbes
 st.view.overview_diagram.Action.shortDescription=Courbes
 
 st.view.help.text=_Aide
-st.view.website.Action.text=Site internet du projet
-st.view.about.Action.text=_A propos
-st.view.about.Action.shortDescription=À propos
+st.view.website.Action.text=Site internet du Projet
+st.view.about.Action.text=_A Propos
+st.view.about.Action.shortDescription=A Propos
 
-st.view.statusbar=%s exercice(s) s\u00E9lectionn\u00E9(s), distance\u00A0: %s, vitesse moyenne\u00A0: %s, dur\u00E9e\u00A0: %s
+st.view.statusbar=%s exercice(s) s\u00E9lectionn\u00E9(s), distance: %s, vitesse moyenne: %s, dur\u00E9e: %s
 st.view.confirm.delete.title=Supprimer l\u02B9entr\u00E9e.
-st.view.confirm.delete.text=Voulez-vous vraiment supprimer cette entr\u00E9e\u00A0?
+st.view.confirm.delete.text=Voulez-vous vraiment supprimer cette entr\u00E9e?
 
 # SportsTracker calendar view
-st.calview.previousMonth.Action.shortDescription=Mois pr\u00E9c\u00E9dent
-st.calview.nextMonth.Action.shortDescription=Mois suivant
-st.calview.previousYear.Action.shortDescription=Ann\u00E9e pr\u00E9c\u00E9dente
-st.calview.nextYear.Action.shortDescription=Ann\u00E9e suivante
+st.calview.previousMonth.Action.shortDescription=Mois Pr\u00E9c\u00E9dent
+st.calview.nextMonth.Action.shortDescription=Mois Suivant
+st.calview.previousYear.Action.shortDescription=Ann\u00E9e Pr\u00E9c\u00E9dente
+st.calview.nextYear.Action.shortDescription=Ann\u00E9e Suivante
 st.calview.today.Action.shortDescription=Aujourd\u02B9hui
 st.calview.months.1=Janvier
 st.calview.months.2=F\u00E9vrier
@@ -131,36 +131,36 @@ st.valview.weekdays.friday=Ve
 st.valview.weekdays.saturday=Sa
 st.valview.weekdays.sunday=Di
 st.valview.week_sum=R\u00E9capitulatif
-st.calview.note_short=N\u00A0:
-st.calview.weight_short=P\u00A0:
-st.calview.exe_tooltip.sport_type=Type de sport\u00A0:
-st.calview.exe_tooltip.distance=Distance\u00A0:
-st.calview.exe_tooltip.avg_speed=Vitesse moyenne\u00A0:
-st.calview.exe_tooltip.duration=Dur\u00E9e\u00A0:
-st.calview.weight_tooltip.weight=Poids\u00A0:
-st.calview.draganddrop.invalid_hrm_file=Vous ne pouvez utiliser qu\u02B9un seul exercice support\u00E9 par ExerciseViewer\u00A0!
+st.calview.note_short=N:
+st.calview.weight_short=P:
+st.calview.exe_tooltip.sport_type=Type de Sport:
+st.calview.exe_tooltip.distance=Distance:
+st.calview.exe_tooltip.avg_speed=Vitesse Moyenne:
+st.calview.exe_tooltip.duration=Dur\u00E9e:
+st.calview.weight_tooltip.weight=Poids:
+st.calview.draganddrop.invalid_hrm_file=Vous ne pouvez utiliser qu\u02B9un seul exercice support\u00E9 par ExerciseViewer!
 st.calview.draganddrop.assigned=Le fichier HRM a \u00E9t\u00E9 assign\u00E9 \u00E0 l\u02B9exercice.
 
 st.calview.print.title=SportsTracker - Calendrier
 
 # SportsTracker exercise list view
 st.exerciselistview.date=Date
-st.exerciselistview.type=Cat\u00E9gorie sportive
-st.exerciselistview.subtype=Sous-cat\u00E9gorie
+st.exerciselistview.type=Cat\u00E9gorie Sportive
+st.exerciselistview.subtype=Sous-Cat\u00E9gorie
 st.exerciselistview.duration=Dur\u00E9e
 st.exerciselistview.intensity=Intensit\u00E9
 st.exerciselistview.distance=Distance
-st.exerciselistview.avg_speed=Vitesse moyenne
-st.exerciselistview.avg_heartrate=FC moyenne
-st.exerciselistview.ascent=Dénivelé
+st.exerciselistview.avg_speed=Vitesse Moyenne
+st.exerciselistview.avg_heartrate=FC Moyenne
+st.exerciselistview.ascent=Ascension
 st.exerciselistview.energy=Energie
 st.exerciselistview.equipment=Mat\u00E9riel
 st.exerciselistview.comment=Commentaire
 st.exerciselistview.empty=Aucun exercice disponible
-st.exerciselistview.print.title=SportsTracker - Liste des exercices.
+st.exerciselistview.print.title=SportsTracker - Liste des Exercices.
 st.exerciselistview.print.page=Page
-st.exerciselistview.confirm.print_many_exercises.title=Impression de la liste des exercices.
-st.exerciselistview.confirm.print_many_exercises.text=Est-ce que vous voulez imprimer tous les exercices affich\u00E9s\u00A0? Vous pouvez utiliser les filtres\npour r\u00E9duire les exercices a imprimer.
+st.exerciselistview.confirm.print_many_exercises.title=Impression de la liste des Exercices.
+st.exerciselistview.confirm.print_many_exercises.text=Est-ce que vous voulez imprimer tous les Exercices Affich\u00E9s? Vous pouvez utiliser les filtres\npour r\u00E9duire les Exercices a imprimer.
 
 # SportsTracker note list view
 st.notelistview.date=Date
@@ -174,7 +174,7 @@ st.weightlistview.date=Date
 st.weightlistview.weight=Poids
 st.weightlistview.comment=Commentaire
 st.weightlistview.empty=Aucun poids disponible 
-st.weightlistview.print.title=SportsTracker - Liste des poids
+st.weightlistview.print.title=SportsTracker - Liste des Poids
 st.weightlistview.print.page=Page
 
 # Initial sport types created when there there are no defined
@@ -190,26 +190,26 @@ st.initial_sporttypes.running.trail_run=sortie Trail
 st.initial_sporttypes.running.trail_race=Course Trail
 
 # Sport Type List dialog
-st.dlg.sporttype_list.title=Editer la liste des cat\u00E9gories sportives
+st.dlg.sporttype_list.title=Editer la liste des Cat\u00E9gories Sportives
 st.dlg.sporttype_list.add.Action.text=Ajouter
 st.dlg.sporttype_list.edit.Action.text=Editer
 st.dlg.sporttype_list.delete.Action.text=Supprimer
 st.dlg.sporttype_list.close.Action.text=Fermer
 st.dlg.sporttype_list.confirm.delete.title=Supprimer la cat\u00E9gorie sportive
-st.dlg.sporttype_list.confirm.delete.text=Voulez-vous vraiment supprimer cette cat\u00E9gorie sportive\u00A0?
-st.dlg.sporttype_list.confirm.delete_existing.text=Il existe des exercices pour cette cat\u00E9gorie. Ces\nexercices seront supprim\u00E9s aussi.Voulez-vous r\u00E9ellement continuer\u00A0?
+st.dlg.sporttype_list.confirm.delete.text=Voulez-vous vraiment supprimer cette cat\u00E9gorie sportive?
+st.dlg.sporttype_list.confirm.delete_existing.text=Il existe des exercices pour cette cat\u00E9gorie. Ces\nexercices seront supprim\u00E9s aussi.Voulez-vous r\u00E9ellement continuer?
 
 # Sport Type dialog
-st.dlg.sporttype.title=Editer la cat\u00E9gorie sportive
-st.dlg.sporttype.title.add=Ajouter une nouvelle cat\u00E9gorie sportive
-st.dlg.sporttype.properties.text=Propri\u00E9t\u00E9s de la cat\u00E9gorie sportive
-st.dlg.sporttype.name.text=Nom\u00A0:
-st.dlg.sporttype.distance.text=Distance\u00A0:
-st.dlg.sporttype.record_distance.text=Distance record et vitesse moyenne.
-st.dlg.sporttype.color.text=Couleur\u00A0:
+st.dlg.sporttype.title=Editer la Cat\u00E9gorie Sportive
+st.dlg.sporttype.title.add=Ajouter une nouvelle Cat\u00E9gorie Sportive
+st.dlg.sporttype.properties.text=Propri\u00E9t\u00E9s de la Cat\u00E9gorie Sportive
+st.dlg.sporttype.name.text=Nom:
+st.dlg.sporttype.distance.text=Distance:
+st.dlg.sporttype.record_distance.text=Distance Record et Vitesse Moyenne.
+st.dlg.sporttype.color.text=Couleur:
 st.dlg.sporttype.select.Action.text=S\u00E9lection
-st.dlg.sporttype.select.Action.shortDescription=Les exercices seront affich\u00E9s dans la couleur s\u00E9lectionn\u00E9e
-st.dlg.sporttype.subtypes.text=Liste des sous-cat\u00E9gories sportives
+st.dlg.sporttype.select.Action.shortDescription=Les Exercices seront affich\u00E9s dans la Couleur S\u00E9lectionn\u00E9e
+st.dlg.sporttype.subtypes.text=Liste des sous-cat\u00E9gories Sportives
 st.dlg.sporttype.add_subtype.Action.text=Ajouter
 st.dlg.sporttype.edit_subtype.Action.text=Editer
 st.dlg.sporttype.delete_subtype.Action.text=Supprimer
@@ -219,135 +219,135 @@ st.dlg.sporttype.edit_equipment.Action.text=Editer
 st.dlg.sporttype.delete_equipment.Action.text=Supprimer
 st.dlg.sporttype.ok.Action.text=OK
 st.dlg.sporttype.cancel.Action.text=Annuler
-st.dlg.sporttype.colorchooser.title=S\u00E9lectionner la couleur
-st.dlg.sporttype.confirm.delete_subtype.title=Supprimer la sous-cat\u00E9gorie sportive
-st.dlg.sporttype.confirm.delete_subtype.text=Voulez-vous vraiment supprimer la sous-cat\u00E9gorie s\u00E9lectionn\u00E9e\u00A0?
-st.dlg.sporttype.confirm.delete_subtype_existing.text=Il y a des exercices pour cette cat\u00E9gorie. Ces\nexercices seront supprim\u00E9s aussi. Voulez-vous vraiment continuer\u00A0?
+st.dlg.sporttype.colorchooser.title=S\u00E9lectionner la Couleur
+st.dlg.sporttype.confirm.delete_subtype.title=Supprimer la sous-cat\u00E9gorie Sportive
+st.dlg.sporttype.confirm.delete_subtype.text=Voulez-vous vraiment supprimer la sous-cat\u00E9gorie s\u00E9lectionn\u00E9e?
+st.dlg.sporttype.confirm.delete_subtype_existing.text=Il y a des exercices pour cette cat\u00E9gorie. Ces\nexercices seront supprim\u00E9s aussi. Voulez-vous vraiment continuer?
 st.dlg.sporttype.confirm.delete_equipment.title=Supprimer le mat\u00E9riel
-st.dlg.sporttype.confirm.delete_equipment.text=Voulez-vous vraiment supprimer le mat\u00E9riel s\u00E9lectionn\u00E9\u00A0?
-st.dlg.sporttype.confirm.delete_equipment_existing.text=Il y a des exercices pour ce mat\u00E9riel, ils seront\nsupprim\u00E9. Voulez-vous vraiment continuer\u00A0?
-st.dlg.sporttype.error.no_name=Vous devez entrer un nom pour la cat\u00E9gorie\u00A0!
-st.dlg.sporttype.error.name_in_use=Le nom de cette cat\u00E9gorie est d\u00E9j\u00E0 utils\u00E9, choisissez un autre nom\u00A0!
-st.dlg.sporttype.error.no_subtype=Vous devez ajouter au moins une sous-cat\u00E9gorie\u00A0!
+st.dlg.sporttype.confirm.delete_equipment.text=Voulez-vous vraiment supprimer le mat\u00E9riel s\u00E9lectionn\u00E9?
+st.dlg.sporttype.confirm.delete_equipment_existing.text=Il y a des exercices pour ce mat\u00E9riel, ils seront\nsupprim\u00E9. Voulez-vous vraiment continuer?
+st.dlg.sporttype.error.no_name=Vous devez entrer un nom pour la cat\u00E9gorie!
+st.dlg.sporttype.error.name_in_use=Le nom de cette cat\u00E9gorie est d\u00E9j\u00E0 utils\u00E9, choisissez un autre nom!
+st.dlg.sporttype.error.no_subtype=Vous devez ajouter au moins une sous-cat\u00E9gorie!
 
 # Sport Subtype dialog
 st.dlg.sportsubtype.add.title=Ajout d\u02B9une nouvelle sous-cat\u00E9gorie sportive
 st.dlg.sportsubtype.edit.title=Editer la sous-cat\u00E9gorie sportive
-st.dlg.sportsubtype.name=Nom (ex\u00A0: Sortie VTT)\u00A0:
-st.dlg.sportsubtype.error.no_name=Vous devez entrer un nom pour la cat\u00E9gorie\u00A0!
-st.dlg.sportsubtype.error.in_use=Le nom de cette sous-cat\u00E9gorie est d\u00E9j\u00E0 utils\u00E9, choisissez un autre nom\u00A0!
+st.dlg.sportsubtype.name=Nom (ex: MTB Tour):
+st.dlg.sportsubtype.error.no_name=Vous devez entrer un nom pour la cat\u00E9gorie!
+st.dlg.sportsubtype.error.in_use=Le nom de cette sous-cat\u00E9gorie est d\u00E9j\u00E0 utils\u00E9, choisissez un autre nom!
 
 # Equipment dialog
 st.dlg.equipment.add.title=Ajout d\u02B9un nouveau mat\u00E9riel.
 st.dlg.equipment.edit.title=Editer le mat\u00E9riel.
-st.dlg.equipment.name=Nom (ex\u00A0: VTT)\u00A0:
-st.dlg.equipment.error.no_name=Vous devez entrer un nom pour ce mat\u00E9riel\u00A0!
-st.dlg.equipment.error.in_use=Le nom de ce mat\u00E9riel est d\u00E9j\u00E0 utilis\u00E9, choisissez un autre nom\u00A0!
+st.dlg.equipment.name=Nom (ex: VTT):
+st.dlg.equipment.error.no_name=Vous devez entrer un nom pour ce mat\u00E9riel!
+st.dlg.equipment.error.in_use=Le nom de ce mat\u00E9riel est d\u00E9j\u00E0 utilis\u00E9, choisissez un autre nom!
 
 # Exercise dialog
 st.dlg.exercise.title=Editer l\u02B9Exercice
-st.dlg.exercise.title.add=Ajouter un nouvel exercice
+st.dlg.exercise.title.add=Ajouter un Nouvel Exercice
 st.dlg.exercise.main.title=Principal
 st.dlg.exercise.optional.title=Option
 st.dlg.exercise.comment.title=Commentaires
-st.dlg.exercise.date.text=Date\u00A0:
-st.dlg.exercise.time.text=Temps (hh:mm)\u00A0:
-st.dlg.exercise.sport_type.text=Cat\u00E9gorie sportive\u00A0:
-st.dlg.exercise.sport_subtype.text=Sous-cat\u00E9gorie sportive\u00A0:
-st.dlg.exercise.intensity.text=Intensit\u00E9\u00A0:
-st.dlg.exercise.distance.text=Distance (%s)\u00A0:
-st.dlg.exercise.avg_speed.text=Vitesse moyenne (%s)\u00A0:
-st.dlg.exercise.duration.text=Dur\u00E9e (hh:mm:ss)\u00A0:
+st.dlg.exercise.date.text=Date:
+st.dlg.exercise.time.text=Temps (hh:mm):
+st.dlg.exercise.sport_type.text=Cat\u00E9gorie sportive:
+st.dlg.exercise.sport_subtype.text=Sous-cat\u00E9gorie sportive:
+st.dlg.exercise.intensity.text=Intensit\u00E9:
+st.dlg.exercise.distance.text=Distance (%s):
+st.dlg.exercise.avg_speed.text=Vitesse moyenne (%s):
+st.dlg.exercise.duration.text=Dur\u00E9e (hh:mm:ss):
 st.dlg.exercise.auto_calc_distance.Action.text=Calculer automatiquement
 st.dlg.exercise.auto_calc_avg_speed.Action.text=Calculer automatiquement
 st.dlg.exercise.auto_calc_duration.Action.text=Calculer automatiquement
-st.dlg.exercise.ascent.text=Ascension (%s)\u00A0:
-st.dlg.exercise.avg_heartrate.text=FC moyenne (bpm)\u00A0:
-st.dlg.exercise.calories.text=Calories consomm\u00E9es (kcal)\u00A0:
-st.dlg.exercise.hrm_file.text=Fichier HRM\u00A0:
-st.dlg.exercise.hrm_browse.Action.text=…
-st.dlg.exercise.hrm_view.Action.text=Ouvrir le fichier HRM
-st.dlg.exercise.hrm_import.Action.text=Importer le fichier HRM
-st.dlg.exercise.equipment.text=Mat\u00E9riel\u00A0:
+st.dlg.exercise.ascent.text=Ascension (%s):
+st.dlg.exercise.avg_heartrate.text=FC moyenne (bpm):
+st.dlg.exercise.calories.text=Calories consomm\u00E9es (kCal):
+st.dlg.exercise.hrm_file.text=Fichier HRM:
+st.dlg.exercise.hrm_browse.Action.text=...
+st.dlg.exercise.hrm_view.Action.text=Ouvrir le Fichier HRM
+st.dlg.exercise.hrm_import.Action.text=Importer le Fichier HRM
+st.dlg.exercise.equipment.text=Mat\u00E9riel:
 st.dlg.exercise.equipment.none.text=vide
-st.dlg.exercise.comment.text=Commentaires\u00A0:
+st.dlg.exercise.comment.text=Commentaires:
 st.dlg.exercise.copy_comment.Action.text=Copier depuis l\u02B9exercice similaire pr\u00E9c\u00E9dent.
 st.dlg.exercise.ok.Action.text=OK
 st.dlg.exercise.cancel.Action.text=Annuler
-st.dlg.exercise.error.no_hrm_file=Vous devez s\u00E9lectionner un fichier HRM en premier\u00A0!
-st.dlg.exercise.error.date=Vous devez entrer une date valide\u00A0!
-st.dlg.exercise.error.distance=Vous devez entrer une distance valide\u00A0!
-st.dlg.exercise.error.avg_speed=Vous devez entrer une vitesse moyenne valide\u00A0!
-st.dlg.exercise.error.duration=Vous devez entrer une dur\u00E9e valide\u00A0!
-st.dlg.exercise.error.ascent=Vous devez entrer une ascension valide\u00A0!
-st.dlg.exercise.error.avg_heartrate=Vous devez entrer une FC moyenne valide\u00A0!
-st.dlg.exercise.error.calories=Vous devez saisir une consommation de calories valide\u00A0!
-st.dlg.exercise.error.import_console=Erreur dans la lecture ou l\u02B9analyse du fichier HRM '%s'.\n Plus d\u02B9informations dans la sortie console.
-st.dlg.exercise.error.no_sport_type=Vous devez s\u00E9lectionner une cat\u00E9gorie sportive\u00A0!
-st.dlg.exercise.error.no_sport_subtype=Vous devez s\u00E9lectionner une sous-cat\u00E9gorie sportive\u00A0!
-st.dlg.exercise.error.no_intensity=Vous devez s\u00E9lectionner une intensit\u00E9\u00A0!
+st.dlg.exercise.error.no_hrm_file=Vous devez s\u00E9lectionner un fichier HRM en premier!
+st.dlg.exercise.error.date=Vous devez entrer une date valide!
+st.dlg.exercise.error.distance=Vous devez entrer une distance valide!
+st.dlg.exercise.error.avg_speed=Vous devez entrer une vitesse moyenne valide!
+st.dlg.exercise.error.duration=Vous devez entrer une dur\u00E9e valide!
+st.dlg.exercise.error.ascent=Vous devez entrer une ascension valide!
+st.dlg.exercise.error.avg_heartrate=Vous devez entrer une FC moyenne valide!
+st.dlg.exercise.error.calories=Vous devez saisir une consommation de calories valide!
+st.dlg.exercise.error.import_console=Erreur dans la lecture ou l\u02B9analyse du fichier HRM'%s'.\n Plus d\u02B9informations dans la sortie console.
+st.dlg.exercise.error.no_sport_type=Vous devez s\u00E9lectionner une cat\u00E9gorie sportive!
+st.dlg.exercise.error.no_sport_subtype=Vous devez s\u00E9lectionner une sous-cat\u00E9gorie sportive!
+st.dlg.exercise.error.no_intensity=Vous devez s\u00E9lectionner une intensit\u00E9!
 st.dlg.exercise.error.wrong_relation=Il y a un probl\u00E8me entre la distance, la vitesse moyenne et la dur\u00E9e!\nCorriger une valeur s\u02B9il vous plait.
-st.dlg.exercise.error.no_sport_and_subtype=Vous devez s\u00E9lectoinner une cat\u00E9gorie et une sous-cat\u00E9gorie en premier\u00A0!
+st.dlg.exercise.error.no_sport_and_subtype=Vous devez s\u00E9lectoinner une cat\u00E9gorie et une sous-cat\u00E9gorie en premier!
 st.dlg.exercise.error.no_previous_exercise=Il n\u02B9y a pas de commentaires pr\u00E9c\u00E9dents similaires.
 
-st.dlg.hrm_file_open.title=S\u00E9lectionner un fichier HRM
-st.dlg.hrm_file_open.filter_all=Tous les fichiers exerciseviewer
+st.dlg.hrm_file_open.title=S\u00E9lectionner un Fichier HRM
+st.dlg.hrm_file_open.filter_all=Tous les Fichiers exerciseviewer
 st.dlg.hrm_file_open.filter_specific=%s fichiers
 
 # Note dialog
-st.dlg.note.title=Editer une note
-st.dlg.note.title.add=Ajouter une nouvelle note
-st.dlg.note.date.text=Date\u00A0:
-st.dlg.note.time.text=Heure (hh:mm)\u00A0:
-st.dlg.note.text.text=Texte\u00A0:
-st.dlg.note.error.date=Vous devez entrer une date valide\u00A0!
-st.dlg.note.error.no_text=Vous devez entrer un texte\u00A0!
+st.dlg.note.title=Editer une Note
+st.dlg.note.title.add=Ajouter une nouvelle Note
+st.dlg.note.date.text=Date:
+st.dlg.note.time.text=Heure (hh:mm):
+st.dlg.note.text.text=Texte:
+st.dlg.note.error.date=Vous devez entrer une date valide!
+st.dlg.note.error.no_text=Vous devez entrer un texte!
 
 # Weight dialog
-st.dlg.weight.title=Editer un poids
-st.dlg.weight.title.add=Ajouter un nouveau poids
-st.dlg.weight.date.text=Date\u00A0:
-st.dlg.weight.time.text=Heure (hh:mm)\u00A0:
-st.dlg.weight.weight.text=Poids\u00A0:
-st.dlg.weight.comment.text=Commentaires\u00A0:
+st.dlg.weight.title=Editer un Poids
+st.dlg.weight.title.add=Ajouter un nouveau Poids
+st.dlg.weight.date.text=Date:
+st.dlg.weight.time.text=Heure (hh:mm):
+st.dlg.weight.weight.text=Poids:
+st.dlg.weight.comment.text=Commentaires:
 st.dlg.weight.ok.Action.text=OK
 st.dlg.weight.cancel.Action.text=Annuler
-st.dlg.weight.error.date=Vous devez entrer une date valide\u00A0!
-st.dlg.weight.error.weight=Vous devez entrer un poids valide\u00A0!
+st.dlg.weight.error.date=Vous devez entrer une date valide!
+st.dlg.weight.error.weight=Vous devez entrer un poids valide!
 
 
 # Filter dialog
-st.dlg.filter.title=Filtre des exercices
+st.dlg.filter.title=Filtre d\u02B9Exercice
 st.dlg.filter.time_period.text=P\u00E9riode
-st.dlg.filter.from.text=du\u00A0:
-st.dlg.filter.to.text=\u00E0\u00A0:
+st.dlg.filter.from.text=du:
+st.dlg.filter.to.text=\u00E0:
 st.dlg.filter.current_week.Action.text=Semaine actuelle
 st.dlg.filter.current_month.Action.text=Mois actuel
 st.dlg.filter.current_year.Action.text=Ann\u00E9e actuelle
 st.dlg.filter.all_time.Action.text=Tout
 st.dlg.filter.filter.text=Filtre
-st.dlg.filter.sport_type.text=Cat\u00E9gori\u00A0:
-st.dlg.filter.sport_subtype.text=Sous-cat\u00E9gorie\u00A0:
-st.dlg.filter.intensity.text=Intensit\u00E9\u00A0:
-st.dlg.filter.equipment.text=Mat\u00E9riel\u00A0:
-st.dlg.filter.string_comments.text=Chaine dans les commentaires\u00A0:
+st.dlg.filter.sport_type.text=Cat\u00E9gorie:
+st.dlg.filter.sport_subtype.text=Sous-Cat\u00E9gorie:
+st.dlg.filter.intensity.text=Intensit\u00E9:
+st.dlg.filter.equipment.text=Mat\u00E9riel:
+st.dlg.filter.string_comments.text=Chaine dans les commentaires:
 st.dlg.filter.reg_expression.text=Mode expression r\u00E9guli\u00E8re (case sensitive)
 st.dlg.filter.ok.Action.text=Valider
 st.dlg.filter.cancel.Action.text=Annuler
 st.dlg.filter.all.text=Tout
-st.dlg.filter.error.date=Vous devez entrer une date valide\u00A0!
-st.dlg.filter.error.start_after_end=La date de d\u00E9but doit \u00EAtre inf\u00E9rieure \u00E0 la date de fin\u00A0!
+st.dlg.filter.error.date=Vous devez entrer une date valide!
+st.dlg.filter.error.start_after_end=La date de d\u00E9but doit \u00EAtre inf\u00E9rieure \u00E0 la date de fin!
 st.dlg.filter.error.reg_expression_error=Erreur de syntaxe dans l\u02B9expression r\u00E9guli\u00E8re de recherche.
 
 # Statistics dialog
 st.dlg.statistic.title=Statistiques
 st.dlg.statistic.current_filter.text=Filtre Actuel
-st.dlg.statistic.timespan.text=P\u00E9riode\u00A0:
-st.dlg.statistic.sport_type.text=Cat\u00E9gorie\u00A0:
-st.dlg.statistic.sport_subtype.text=Sous-Cat\u00E9gorie\u00A0:
-st.dlg.statistic.intensity.text=Intensit\u00E9\u00A0:
-st.dlg.statistic.equipment.text=Mat\u00E9riel\u00A0:
-st.dlg.statistic.comment.text=Commentaires\u00A0:
+st.dlg.statistic.timespan.text=P\u00E9riode:
+st.dlg.statistic.sport_type.text=Cat\u00E9gorie:
+st.dlg.statistic.sport_subtype.text=Sous-Cat\u00E9gorie:
+st.dlg.statistic.intensity.text=Intensit\u00E9:
+st.dlg.statistic.equipment.text=Mat\u00E9riel:
+st.dlg.statistic.comment.text=Commentaires:
 st.dlg.statistic.all.text=tout
 st.dlg.statistic.no_comment.text=(vide)
 st.dlg.statistic.reg_expression.text=(Expression r\u00E9guli\u00E8re)
@@ -362,16 +362,16 @@ st.dlg.statistic_results.total.text=Total
 st.dlg.statistic_results.minimum.text=Minimum
 st.dlg.statistic_results.average.text=Moyenne
 st.dlg.statistic_results.maximum.text=Maximum
-st.dlg.statistic_results.total_exercises.text=Exercices\u00A0:
-st.dlg.statistic_results.total_distance.text=Distance totale\u00A0:
-st.dlg.statistic_results.total_duration.text=Dur\u00E9e totale\u00A0:
-st.dlg.statistic_results.total_ascent.text=Dénivelé total\u00A0:
-st.dlg.statistic_results.distance.text=Distance\u00A0:
-st.dlg.statistic_results.avg_speed.text=Vitesse Moyenne\u00A0:
-st.dlg.statistic_results.duration.text=Dur\u00E9e\u00A0:
-st.dlg.statistic_results.ascent.text=Dénivelé\u00A0:
-st.dlg.statistic_results.avg_heartrate.text=FC moyenne\u00A0:
-st.dlg.statistic_results.calories.text=Calories consomm\u00E9es\u00A0:
+st.dlg.statistic_results.total_exercises.text=Exercices:
+st.dlg.statistic_results.total_distance.text=Distance Totale:
+st.dlg.statistic_results.total_duration.text=Dur\u00E9e Totale:
+st.dlg.statistic_results.total_ascent.text=Ascension Totale:
+st.dlg.statistic_results.distance.text=Distance:
+st.dlg.statistic_results.avg_speed.text=Vitesse Moyenne:
+st.dlg.statistic_results.duration.text=Dur\u00E9e:
+st.dlg.statistic_results.ascent.text=Ascension:
+st.dlg.statistic_results.avg_heartrate.text=FC Moyenne:
+st.dlg.statistic_results.calories.text=Calories consomm\u00E9es:
 st.dlg.statistic_results.close.Action.text=Fermer
 
 # Overview dialog
@@ -384,12 +384,12 @@ st.dlg.overview.time_range.weeks_of_year.text=Affichage de toutes les semaines d
 st.dlg.overview.time_range.ten_years.text=Affichage des 10 derni\u00E8res ann\u00E9es
 st.dlg.overview.options.text=Options d\u02B9Affichage
 st.dlg.overview.display.text=Affichage
-st.dlg.overview.display.distance_sum.text=Somme des distances
-st.dlg.overview.display.duration_sum.text=Somme des dur\u00E9es
-st.dlg.overview.display.ascent_sum.text=Somme des dénivelés
-st.dlg.overview.display.calorie_sum.text=Somme des calories consomm\u00E9es
-st.dlg.overview.display.exercise_count.text=Nombre d\u02B9exercices
-st.dlg.overview.display.avg_speed.text=Vitesse moyenne
+st.dlg.overview.display.distance_sum.text=Somme des Distances
+st.dlg.overview.display.duration_sum.text=Somme des Dur\u00E9es
+st.dlg.overview.display.ascent_sum.text=Somme des Ascensions
+st.dlg.overview.display.calorie_sum.text=Somme des Calories consomm\u00E9es
+st.dlg.overview.display.exercise_count.text=Nombre d\u02B9Exercices
+st.dlg.overview.display.avg_speed.text=Vitesse Moyenne
 st.dlg.overview.display.sportsubtype_distance.text=Distance par sous-cat\u00E9gorie sportive
 st.dlg.overview.display.equipment_distance.text=Distance par \u00E9quipement
 st.dlg.overview.display.weight.text=Poids
@@ -399,12 +399,12 @@ st.dlg.overview.sport_type.each_splitted.text=Chaques Cat\u00E9gories s\u00E9par
 st.dlg.overview.sport_type.each_stacked.text=Chaques Cat\u00E9gories s\u00E9par\u00E9s (Regroup\u00E9es)
 st.dlg.overview.sport_type.all_summary.text=Toutes les Cat\u00E9gories regroup\u00E9es.
 st.dlg.overview.close.Action.text=Fermer
-st.dlg.overview.value_type.distance_sum=Somme des distances (%s)
-st.dlg.overview.value_type.duration_sum=Somme des dur\u00E9es (hours)
-st.dlg.overview.value_type.ascent_sum=Somme des ascensions (%s)
-st.dlg.overview.value_type.calories_sum=Somme des calories consomm\u00E9es (kcal)
+st.dlg.overview.value_type.distance_sum=Somme des Distances(%s)
+st.dlg.overview.value_type.duration_sum=Somme des Dur\u00E9es(hours)
+st.dlg.overview.value_type.ascent_sum=Somme des Ascensions(%s)
+st.dlg.overview.value_type.calories_sum=Somme des Calories Consomm\u00E9es(kCal)
 st.dlg.overview.value_type.exercise_count=Nombre d\u02B9Exercices
-st.dlg.overview.value_type.avg_speed=Vitesse moyenne (%s)
+st.dlg.overview.value_type.avg_speed=Vitesse Moyenne(%s)
 st.dlg.overview.value_type.sportsubtype_distance=Distance par sous-cat\u00E9gorie sportive (%s)
 st.dlg.overview.value_type.equipment_distance=Distance par \u00E9quipement (%s)
 st.dlg.overview.value_type.weight=Poids (%s)
@@ -414,25 +414,25 @@ st.dlg.overview.equipment.not_specified=Non sp\u00E9cifi\u00E9
 # Options dialog
 st.dlg.options.title=Pr\u00E9f\u00E9rences
 st.dlg.options.main.title=Principale
-st.dlg.options.units.title=Unit\u00E9s
+st.dlg.options.units.title=Unit\u00E9es
 st.dlg.options.listview.title=Liste des exercices
 st.dlg.options.exerciseviewer.title=ExerciseViewer
 st.dlg.options.initial_view.text=Affichage par d\u00E9faut
 st.dlg.options.calendar.text=Calendrier
-st.dlg.options.exercise_list.text=Listes des exercices
-st.dlg.options.defaultautocalc.text=Calcul automatique par d\u00E9faut\u00A0:
-st.dlg.options.distance.text=Calcul de la distance.
-st.dlg.options.avg_speed.text=Calcul de la vitesse moyenne.
-st.dlg.options.duration.text=Calcul de la dur\u00E9e
-st.dlg.options.week_start.text=D\u00E9but de semaine
+st.dlg.options.exercise_list.text=Listes des Exercices
+st.dlg.options.defaultautocalc.text=Calcul automatique par d\u00E9faut:
+st.dlg.options.distance.text=Calcul de la Distance.
+st.dlg.options.avg_speed.text=Calcul de la Vitesse Moyenne.
+st.dlg.options.duration.text=Calcul de la Dur\u00E9e
+st.dlg.options.week_start.text=D\u00E9but de Semaine
 st.dlg.options.monday.text=Lundi
 st.dlg.options.sunday.text=Dimanche
 st.dlg.options.unit_system.text=Unit\u00E9
-st.dlg.options.metric.text=M\u00E9trique (ex\u00A0: kilom\u00E8tres)
-st.dlg.options.english.text=Anglais (ex\u00A0: miles)
-st.dlg.options.speed_unit.text=Affichage de la vitesse
-st.dlg.options.distance_hour.text=Distance par heure (ex\u00A0: km/h)
-st.dlg.options.minutes_distance.text=Minutes par km (ex\u00A0: min/km)
+st.dlg.options.metric.text=M\u00E9trique (ex: kilom\u00E8tres)
+st.dlg.options.english.text=Anglais (ex: miles)
+st.dlg.options.speed_unit.text=Affichage de la Vitesse
+st.dlg.options.distance_hour.text=Distance par heure (ex: km/h)
+st.dlg.options.minutes_distance.text=Minutes par Km (ex: min/km)
 st.dlg.options.save_exit.text=Enregistrement
 st.dlg.options.autosave_exit.text=Enregistrer automatiquement en quittant
 st.dlg.options.list_optional_fields.text=Affichage de champs optionnels
@@ -450,19 +450,19 @@ st.dlg.options.cancel.Action.text=Annuler
 # About dialog
 st.dlg.about.title=A Propos de SportsTracker
 st.dlg.about.description.text=Un outil pour enregistrer vos activit\u00E9s sportives, et consulter vos fichiers d\u02B9exercices.\nEcrit gr\u00E2ce \u00E0 la plateforme Java.
-st.dlg.about.license.text=License\u00A0: GNU General Public License (GPL), Version 2
+st.dlg.about.license.text=License: GNU General Public License (GPL), Version 2
 st.dlg.about.title.authors=Auteurs
 st.dlg.about.title.translators=Traducteurs
 st.dlg.about.translators.text=\
-Basque\u00A0:\n    Asier Urio Larrea <asieriko@gmail.com>\n\n\
-Tch\u00E8que\u00A0:\n    Petr Marcik <marcikp@seznam.cz>\n\n\
-Danois\u00A0:\n    Jacob Ils\u00F8 Christensen <jacobilsoe@gmail.com>\n\n\
-Hollandais\u00A0:\n    Eric Spierings <ericspierings@netscape.net>\n\n\
-Fran\u00E7ais\u00A0:\n    Nicolas Ollivier <nicollivier@gmail.com>\n\n\
-Allemand\u00A0:\n    Stefan Saring <projects@saring.de>\n\n\
-Cor\u00E9en\u00A0:\n      Tae Young Ko <oscetic@gmail.com>\n\n\
-Polonais\u00A0:\n    Zbigniew Ogl\u0119dzki <zgibek@gazeta.pl>\n\n\
-Espaghnol\u00A0:\n    Asier Urio Larrea <asieriko@gmail.com>,\n    Luis Llorente Campo <luisllorente@luisllorente.com>
+Basque:\n    Asier Urio Larrea <asieriko@gmail.com>\n\n\
+Tch\u00E8que:\n    Petr Marcik <marcikp@seznam.cz>\n\n\
+Danois:\n    Jacob Ils\u00F8 Christensen <jacobilsoe@gmail.com>\n\n\
+Hollandais:\n    Eric Spierings <ericspierings@netscape.net>\n\n\
+Fran\u00E7ais:\n    Nicolas Ollivier <nicollivier@gmail.com>\n\n\
+Allemand:\n    Stefan Saring <projects@saring.de>\n\n\
+Cor\u00E9en:\n      Tae Young Ko <oscetic@gmail.com>\n\n\
+Polonais:\n    Zbigniew Ogl\u0119dzki <zgibek@gazeta.pl>\n\n\
+Espaghnol:\n    Asier Urio Larrea <asieriko@gmail.com>,\n    Luis Llorente Campo <luisllorente@luisllorente.com>
 
 
 #####################################################################
@@ -479,40 +479,40 @@ pv.view.close.Action.text=Fermer
 
 # ExerciseViewer Main panel
 pv.main.general_data.text=Donn\u00E9es G\u00E9n\u00E9rales
-pv.main.type.text=Sport\u00A0:
-pv.main.user.text=Utilisateur\u00A0:
-pv.main.date.text=Date\u00A0:
-pv.main.duration.text=Dur\u00E9e\u00A0:
-pv.main.energy.text=Energie\u00A0:
+pv.main.type.text=Sport:
+pv.main.user.text=Utilisateur:
+pv.main.date.text=Date:
+pv.main.duration.text=Dur\u00E9e:
+pv.main.energy.text=Energie:
 pv.main.heartrate_data.text=Donn\u00E9es Cardiaques
-pv.main.average.text=Moyenne\u00A0:
-pv.main.maximum.text=Maximum\u00A0:
+pv.main.average.text=Moyenne:
+pv.main.maximum.text=Maximum:
 pv.main.heartrate_limits.text=Limites FC
-pv.main.range.text=Plage\u00A0:
-pv.main.time_below.text=Dur\u00E9e en-dessous\u00A0:
-pv.main.time_within.text=Dur\u00E9e dans la plage\u00A0:
-pv.main.time_above.text=Dur\u00E9e au-dessus\u00A0:
-pv.main.recording_mode.text=Mode enregistrement
-pv.main.altitude.text=Altitude\u00A0:
-pv.main.speed.text=Vitesse\u00A0:
-pv.main.cadence.text=Cadence\u00A0:
-pv.main.power.text=Puissance\u00A0:
+pv.main.range.text=Plage:
+pv.main.time_below.text=Dur\u00E9e en-dessous:
+pv.main.time_within.text=Dur\u00E9e dans la plage:
+pv.main.time_above.text=Dur\u00E9e au-dessus:
+pv.main.recording_mode.text=Mode Enregistrement
+pv.main.altitude.text=Altitude:
+pv.main.speed.text=Vitesse:
+pv.main.cadence.text=Cadence:
+pv.main.power.text=Puissance:
 pv.main.statistics.text=Statistiques
-pv.main.total_exercise_time.text=Dur\u00E9e total des exercices\u00A0:
-pv.main.total_riding_time.text=Dur\u00E9e total de v\u00E9lo\u00A0:
-pv.main.total_energy.text=Total energ\u00E9tique\u00A0:
-pv.main.odometer.text=Odom\u00E8tre\u00A0:
+pv.main.total_exercise_time.text=Dur\u00E9e total des exercices:
+pv.main.total_riding_time.text=Dur\u00E9e total de v\u00E9lo:
+pv.main.total_energy.text=Total energ\u00E9tique:
+pv.main.odometer.text=Odom\u00E8tre:
 
 # ExerciseViewer Optional panel
 pv.opt.speed_data.text=Vitesse
-pv.opt.minimum.text=Minimum\u00A0:
-pv.opt.average.text=Moyenne\u00A0:
-pv.opt.maximum.text=Maximum\u00A0:
-pv.opt.distance.text=Distance\u00A0:
-pv.opt.bike_nr.text=Num\u00E9ro du v\u00E9lo\u00A0:
+pv.opt.minimum.text=Minimum:
+pv.opt.average.text=Moyenne:
+pv.opt.maximum.text=Maximum:
+pv.opt.distance.text=Distance:
+pv.opt.bike_nr.text=Num\u00E9ro du v\u00E9lo:
 pv.opt.cadence_data.text=Cadence
 pv.opt.altitude_data.text=Altitude
-pv.opt.ascent.text=Ascension\u00A0:
+pv.opt.ascent.text=Ascension:
 pv.opt.temperature_data.text=Temp\u00E9rature
 
 # ExerciseViewer Laps panel
@@ -543,9 +543,9 @@ pv.samples.temperature=Temp\u00E9rature
 
 # ExerciseViewer Diagram panel
 pv.diagram.axis_usage.text=Donn\u00E9es des axes
-pv.diagram.left.text=Gauche\u00A0:
-pv.diagram.right.text=Droite\u00A0:
-pv.diagram.bottom.text=inf\u00E9rieur\u00A0:
+pv.diagram.left.text=Gauche:
+pv.diagram.right.text=Droite:
+pv.diagram.bottom.text=inf\u00E9rieur:
 pv.diagram.axis.nothing=rien
 pv.diagram.axis.heartrate=Fc (bpm)
 pv.diagram.axis.altitude=altitude (%s)
@@ -565,4 +565,4 @@ pv.track.tooltip.altitude=Altitude
 pv.track.tooltip.heartrate=Fr\u00E9quence cardiaque
 pv.track.tooltip.speed=Vitesse
 pv.track.tooltip.temperature=Temp\u00E9rature
-pv.track.position.text=Position\u00A0:
+pv.track.position.text=Position:


### PR DESCRIPTION
Reverts ssaring/sportstracker#2

I'm sorry that I have to revert this pull request, but there are multiple errors with the provided translation update. 

Examples:
* Exercise Dialog: strange special characters instead of '...' for the browse HRM file button
* Statistic Result Dialog: strange special characters in the labels which look like a copyright symbol

Could you please fix those errors and test the translations in all dialogs? I have only tested the two dialogs above.

Bye, Stefan