### PR TITLE
Calendar View: today is highlighted

### DIFF
--- a/sportstracker/docs/CHANGES.txt
+++ b/sportstracker/docs/CHANGES.txt
@@ -3,7 +3,9 @@ Changelog
 
 v7.4.1:
  SportsTracker changes:
- - Calendar View: removed layout workarounds (JavaFX bugs have been fixed)
+ - Calendar View:
+   - Issue #141: today is highlighted in a blue circle (red  for sundays)
+   - removed layout workarounds (JavaFX bugs have been fixed)
  ExerciseViewer changes:
  - removed compiler warnings in LeafletMap component
 

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -14,8 +14,6 @@ JavaFX Migration:
     (see https://bitbucket.org/controlsfx/controlsfx/issues/539/multiple-dialog-fields-with-validation )
   - workaround is to setup the validation after the dialog has been shown (with Platform.invokeLater(...)
     => remove after the bug has been fixed in Filter-, Note- and Weight Dialog
-- Calendar: current day must be better recognizable, see
-  https://sourceforge.net/p/sportstracker/feature-requests/80/
 - ExerciseViewer: Done & tested
   - Bug (also with JavaFX 8u40): EV window is always placed in screen center, not placed at center of parent window
     (initially, when no previous window bounds were persisted)

--- a/st-util/src/main/java/de/saring/util/gui/javafx/control/calendar/AbstractCalendarCell.java
+++ b/st-util/src/main/java/de/saring/util/gui/javafx/control/calendar/AbstractCalendarCell.java
@@ -5,6 +5,7 @@ import java.util.List;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 
 /**
@@ -25,12 +26,15 @@ abstract class AbstractCalendarCell extends VBox {
         setPadding(new Insets(3, 4, 3, 4));
         setSpacing(3);
 
+        HBox hbNumber = new HBox();
+        hbNumber.setAlignment(Pos.CENTER_RIGHT);
+        getChildren().add(hbNumber);
+
         laNumber = new Label();
-        laNumber.setAlignment(Pos.CENTER_RIGHT);
-        laNumber.setMaxWidth(Double.MAX_VALUE);
-        getChildren().add(laNumber);
+        hbNumber.getChildren().add(laNumber);
 
         getStyleClass().add("calendar-control-cell");
+        hbNumber.getStyleClass().add("number-panel");
         getNumberLabel().getStyleClass().add("number");
     }
 
@@ -40,7 +44,9 @@ abstract class AbstractCalendarCell extends VBox {
      * @param number number to display
      */
     public void setNumber(final int number) {
-        laNumber.setText(String.valueOf(number));
+        // add spaces around day number when < 10 => otherwise the highlighted background for today is too slim
+        String preSuffix = number < 10 ? " " : "";
+        laNumber.setText(preSuffix + String.valueOf(number) + preSuffix);
     }
 
     /**

--- a/st-util/src/main/resources/de/saring/util/gui/javafx/control/calendar/CalendarControl.css
+++ b/st-util/src/main/resources/de/saring/util/gui/javafx/control/calendar/CalendarControl.css
@@ -25,28 +25,42 @@
 }
 
 /* Style of the upper left number of calendar cells. */
-.calendar-control-cell > .number {
+.calendar-control-cell > .number-panel > .number {
     -fx-text-fill-default: black;
     -fx-text-fill-sunday: red;
-    -fx-text-fill-today: darkblue;
+    -fx-text-fill-today: white;
     -fx-text-fill: -fx-text-fill-default;
+
+    -fx-text-background-today: cornflowerblue;
+    -fx-text-background-today-sunday: orangered;
 }
 
-.calendar-control-cell > .number:today {
-    -fx-text-fill: -fx-text-fill-today;
-    -fx-font-weight: bold;
-}
-
-.calendar-control-cell > .number:sunday {
+.calendar-control-cell > .number-panel > .number:sunday {
     -fx-text-fill: -fx-text-fill-sunday;
 }
 
-.calendar-control-cell > .number:outside-month {
+.calendar-control-cell > .number-panel > .number:today {
+    -fx-text-fill: -fx-text-fill-today;
+    -fx-background-color: -fx-text-background-today;
+    -fx-font-weight: bold;
+    -fx-background-insets: -2 -3 -2 -3;
+    -fx-background-radius: 30;
+}
+
+.calendar-control-cell > .number-panel > .number:today:sunday {
+    -fx-background-color: -fx-text-background-today-sunday;
+}
+
+.calendar-control-cell > .number-panel > .number:outside-month {
     -fx-text-fill: derive(-fx-text-fill-default, 90%);
 }
 
-.calendar-control-cell > .number:sunday:outside-month {
+.calendar-control-cell > .number-panel > .number:sunday:outside-month {
     -fx-text-fill: derive(-fx-text-fill-sunday, 90%);
+}
+
+.calendar-control-cell > .number-panel > .number:outside-month:today {
+    -fx-text-fill: derive(-fx-text-fill-today, 90%);
 }
 
 /* Style of calendar header cells. */
@@ -80,4 +94,3 @@
     /* increase the downsized tooltip font size */
     -fx-font-size: 0.9em;
 }
-


### PR DESCRIPTION
Implementation for Issue #141: Current day is now better recognizable, the day number is highlighted in a blue circle (red for sundays).