### PR TITLE
Migrate all unit test to Junit 5 (Jupiter API)

### DIFF
--- a/leafletmap/README.md
+++ b/leafletmap/README.md
@@ -11,7 +11,7 @@ Both the LeafletMap component and the demo application are written in Kotlin.
 
 #### Dependencies and used libraries
 
-* Kotlin 1.2.0
+* Kotlin 1.2.21
 * JavaSE 8 (tested with 8u151 and 9.0.1)
 * Leaflet 1.0.3 (included)
     * Homepage: http://leafletjs.com/

--- a/leafletmap/README.md
+++ b/leafletmap/README.md
@@ -20,7 +20,7 @@ Both the LeafletMap component and the demo application are written in Kotlin.
 * leaflet-color-markers (included, modified)
     * Homepage: https://github.com/pointhi/leaflet-color-markers
     * License: not specified
-* jackson-module-kotlin 2.9.1 (for the demo only, uses Jackson 2.8)
+* jackson-module-kotlin 2.9.4.1 (for the demo only, uses Jackson 2.8)
     * Homepage: https://github.com/FasterXML/jackson-module-kotlin
     * License: not specified
 

--- a/leafletmap/pom.xml
+++ b/leafletmap/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kotlin.version>1.2.0</kotlin.version>
+        <kotlin.version>1.2.21</kotlin.version>
     </properties>
     
     <dependencies>

--- a/leafletmap/pom.xml
+++ b/leafletmap/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
-            <version>2.9.1</version>
+            <version>2.9.4.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <application.name>SportsTracker</application.name>
         <application.mainClass>de.saring.sportstracker.gui.STApplication</application.mainClass>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.0.3</junit.version>
     </properties>
     
     <modules>
@@ -64,21 +65,15 @@
         </dependency>
         <!-- Common test dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>2.10.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>de.saxsys</groupId>
-            <artifactId>jfx-testrunner</artifactId>
-            <version>1.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -94,6 +89,25 @@
                     <target>9</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
+            </plugin>
+
+            <!-- Surefire setup for proper JUnit 5 test execution (does not work by default yet) -->
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <!-- Surefire plugin version 2.20 has a bug, no tests will be executed then -->
+                <version>2.19.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-surefire-provider</artifactId>
+                        <version>1.0.3</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>${junit.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/sportstracker/docs/CHANGES.txt
+++ b/sportstracker/docs/CHANGES.txt
@@ -15,6 +15,8 @@ v7.5.0:
  - added official JFreeChart-FX 1.0.0 library, custom patch not needed anymore
  - updated Kotlin to version 1.2.21
  - updated documentation for project import and IDE setup in IDEA and Eclipse
+ - migrated all unit tests to JUnit 5 (version 5.0.3)
+   - provides better testing of expected exception calls and handling
  ExerciseViewer changes:
  - GarminFitParser: bugfix for handling of missing sample data,
    e.g. temperature, heartrate, speed

--- a/sportstracker/docs/CHANGES.txt
+++ b/sportstracker/docs/CHANGES.txt
@@ -13,7 +13,7 @@ v7.5.0:
  - fixed encoding problems in dutch translation
  - update to JFreeChart 1.5.0, does not need the JCommon library anymore
  - added official JFreeChart-FX 1.0.0 library, custom patch not needed anymore
- - updated Kotlin to version 1.2.0
+ - updated Kotlin to version 1.2.21
  ExerciseViewer changes:
  - GarminFitParser: bugfix for handling of missing sample data,
    e.g. temperature, heartrate, speed

--- a/sportstracker/docs/CHANGES.txt
+++ b/sportstracker/docs/CHANGES.txt
@@ -14,6 +14,7 @@ v7.5.0:
  - update to JFreeChart 1.5.0, does not need the JCommon library anymore
  - added official JFreeChart-FX 1.0.0 library, custom patch not needed anymore
  - updated Kotlin to version 1.2.21
+ - updated documentation for project import and IDE setup in IDEA and Eclipse
  ExerciseViewer changes:
  - GarminFitParser: bugfix for handling of missing sample data,
    e.g. temperature, heartrate, speed

--- a/sportstracker/docs/README.txt
+++ b/sportstracker/docs/README.txt
@@ -426,8 +426,6 @@ The SportsTracker project uses the following libraries:
       URL: http://www.thisisant.com/pages/products/fit-sdk
       License: FIT Protocol License (open source by Dynastream / Garmin)
       License URL: https://www.thisisant.com/resources/fit
-  - jfx-testrunner 1.2 (https://github.com/sialcasa/jfx-testrunner)
-      License: Apache License v2.0
 
 All dependencies will be downloaded automatically by Maven. The Garmin FIT
 library is missing in the Maven central repository, so I've created my own

--- a/sportstracker/docs/README.txt
+++ b/sportstracker/docs/README.txt
@@ -406,7 +406,7 @@ The SportsTracker project uses the following libraries:
   - EasyDI 0.3.0 (https://github.com/lestard/EasyDI)
       Includes: javax.inject-1.jar
       License: Apache License v2.0
-  - Kotlin 1.2.0 (http://kotlinlang.org/)
+  - Kotlin 1.2.21 (http://kotlinlang.org/)
       License: Apache License v2.0
   - JDOM 2.0.6 (http://www.jdom.org)
       License: Apache-style open source license
@@ -514,4 +514,4 @@ based on the IcoMoon icons.
 
 
 Stefan Saring
-2017/11/29
+2018/02/10

--- a/sportstracker/docs/README.txt
+++ b/sportstracker/docs/README.txt
@@ -418,8 +418,8 @@ The SportsTracker project uses the following libraries:
       License: Apache License v2.0
   - sqlite-jdbc 3.20.0 (https://github.com/xerial/sqlite-jdbc)
       License: Apache License v2.0
-  - JUnit 4.12 (http://www.junit.org)
-      License: Common Public License v1.0
+  - JUnit 5.0.3 (http://www.junit.org)
+      License: Eclipse Public License v2.0. and Apache License v2.0
   - Mockito 2.10.0 (http://code.google.com/p/mockito/)
       License: MIT License
   - Flexible & Interoperable Data Transfer (FIT) Protocol SDK 20.33.01

--- a/sportstracker/docs/README.txt
+++ b/sportstracker/docs/README.txt
@@ -351,14 +351,14 @@ Developer Requirements
 ----------------------
 
 For compilation of the SportsTracker sources you need:
-  - Java SE Development Kit (JDK) 8u40 or greater
+  - Java SE Development Kit (JDK) 9 or greater
     (from http://www.oracle.com/technetwork/java/)
-  - Maven 3.0.3 or greater
+  - Maven 3.5.0 or greater
     (from http://maven.apache.org)
 
 Tested IDE's (should work an any IDE with Maven support)
   - IntelliJ IDEA Community Edition (http://www.jetbrains.com/idea/)
-    => preferred IDE, tested with version 2017.2
+    => preferred IDE, tested with version 2017.3
   - NetBeans IDE (from http://www.netbeans.org), Kotlin support not tested
   - Eclipse (from http://eclipse.org), Kotlin support not tested
 
@@ -381,23 +381,18 @@ multi project), so it's not possible to create circular module dependencies.
   - leafletmap:
     Module for the JavaFX wrapper component of the Leaflet map viewer
 
-In NetBeans you can open the project by "Open project", you need to select the
-project root directory and import all required projects.
-In Eclipse you can open the project by "Import -> Existing Maven Projects",
-you need to select the project root directory with all child modules here.
-IntelliJ IDEA users need to import the project by "File -> Import Project...",
-select the SportsTracker root directory and import it as a Maven project.
+The configuration of your IDE (IDEA or Eclipse) is documented in the folder
+'misc/ide-configuration'. It contains instructions how to import the project
+into your IDE and how to setup the code formatter properly.
+It's important to ensure a consistent code format and style all over the
+project. That's why all developers need to use the same configuration for their
+IDE.
 
 SportStracker can be started from the IDE by executing the class
 "de.saring.sportstracker.gui.STApplication".
 It can also be started from command line after execution of "mvn package"
 with the command (inside the project root directory):
   java -jar sportstracker/target/sportstracker-x.y.z.jar
-
-It's important to ensure a consistent code format and style all over the
-project. That's why all developers need to use the same configuration for their
-IDE. This configuration and the documentation can be found in the directory
-'sportstracker/misc/ide-configuration'.
 
 All user interfaces are defined in FXML by using the JavaFX Scene Builder 8.x.
 

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -1,9 +1,6 @@
 SportsTracker-TODO
 ==================
 
-JUnit 5 migration:
-- see TODOs in BindingUtilsToggleGroupTest -> JFXRunner is not working in JUnit 5 anymore
-
 Java 9 migration:
 - completed (no compile errors, no test errors, no usage problems)
 - JavaFX packaging does not work yet, see details in the st-packager module

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -1,6 +1,9 @@
 SportsTracker-TODO
 ==================
 
+JUnit 5 migration:
+- see TODOs in BindingUtilsToggleGroupTest -> JFXRunner is not working in JUnit 5 anymore
+
 - Update jackson-module-kotlin dependency when there is a release for Kotlin 1.2
   (currently there are warnings for conflicting Kotlin libraries)
 

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -4,9 +4,6 @@ SportsTracker-TODO
 JUnit 5 migration:
 - see TODOs in BindingUtilsToggleGroupTest -> JFXRunner is not working in JUnit 5 anymore
 
-- Update jackson-module-kotlin dependency when there is a release for Kotlin 1.2
-  (currently there are warnings for conflicting Kotlin libraries)
-
 Java 9 migration:
 - completed (no compile errors, no test errors, no usage problems)
 - JavaFX packaging does not work yet, see details in the st-packager module
@@ -18,8 +15,6 @@ Java 9 migration:
   - JavaFX support might be added in Java 10: https://bugs.openjdk.java.net/browse/JDK-8091107
 
 - Add an update notification when a new SportsTracker version has been released
-
-- Migrate to JUnit 5 -> see https://vocabhunter.github.io/2017/10/17/migrating-to-junit-5.html
 
 JavaFX Migration:
 - Migration status: completed, Swing is not in use anymore

--- a/sportstracker/misc/ide-configuration/IDE-Configuration.txt
+++ b/sportstracker/misc/ide-configuration/IDE-Configuration.txt
@@ -20,40 +20,31 @@ modified source code parts needs to be formatted, not the whole files or
 packages.
 
 
-Eclipse configuration (version 4.4):
-------------------------------------
+IntelliJ IDEA configuration (version 2017.x):
+---------------------------------------------
 
-- Preferences:
-  - General -> Workspace:
-    - Text file encoding: UTF-8
-  - General -> Editors - Text Editors:
-    - (x) Insert spaces for tabs
-  - Java -> Code Style -> Formatter: 
-    - Import file "ST-Formatter.xml" and select active profile "SportsTracker"
-  - Java -> Code Style -> Organize Imports: 
-    - Import file "ST-Imports.importorder"
-    - Number of imports needed for .*: 999
-    - Number of static imports needed for .*: 999
-  - Java -> Editor -> Save Actions: 
-    - (x) Perform the selected actions on save
-        (x) Format source code
-           (x) Format edited lines
-        (x) Organize imports
-  - XML -> XML Files -> Editor:
-    - Line Width: 240
-    - ( ) Split multiple attributes each on a new line
-    - (x) Indent using spaces
-    - Indentation size: 4
+Project import:
 
-    
-IntelliJ IDEA configuration (version 14.x):
--------------------------------------------
+- Import Project in launch screen (or File -> Open)
+- Select the pom.xml file in the SportsTracker root directory
+- Un/Select these options in the import dialog:
+  ( ) Search for projects recursively
+  (x) Import Maven projects automatically
+  (x) Keep project files in: PROJECT_DIRECTORY/.idea
+      (PROJECT_DIRECTORY is your project folder)
+  (x) Create IntelliJ IDEA modules for aggregator projects
+  (x) Create module groups for multi-module Maven projects
+  -> keep all the other options as they are
+  
+
+Code Style configuration:
 
 - File -> Settings:
   - Plugins: 
     - install plugin "Eclipse Code Formatter" (version 15.x) and restart IDEA
   - Eclipse Code Formatter:
     - (x) Use the Eclipse code formatter
+	- Create a Project specific profile
     - Eclipse Java Formatter config file: 
       - select file "ST-Formatter.xml" 
     - Java Formatter Profile:
@@ -76,9 +67,42 @@ IntelliJ IDEA configuration (version 14.x):
         - (x) Align attributes
         
 - Formatter must be used manually on the edited Java and FXML files 
- (Code -> Reformat Code) with the selected options:
-  (x) File '...'
-  (x) Organize imports
+ (Code -> Show Reformat File Dialog) with the selected options:
   (x) Only VCS changed text
+  (x) Organize imports
 - For FXML files make sure that there are no unused and wildcard imports
   (performance brake)
+
+
+Eclipse configuration (version 4.4, recent versions untested):
+--------------------------------------------------------------
+
+Project import:
+
+- open the project by "Import -> Existing Maven Projects"
+- you need to select the project root directory with all child modules here
+
+
+Code Style configuration:
+
+- Preferences:
+  - General -> Workspace:
+    - Text file encoding: UTF-8
+  - General -> Editors - Text Editors:
+    - (x) Insert spaces for tabs
+  - Java -> Code Style -> Formatter: 
+    - Import file "ST-Formatter.xml" and select active profile "SportsTracker"
+  - Java -> Code Style -> Organize Imports: 
+    - Import file "ST-Imports.importorder"
+    - Number of imports needed for .*: 999
+    - Number of static imports needed for .*: 999
+  - Java -> Editor -> Save Actions: 
+    - (x) Perform the selected actions on save
+        (x) Format source code
+           (x) Format edited lines
+        (x) Organize imports
+  - XML -> XML Files -> Editor:
+    - Line Width: 240
+    - ( ) Split multiple attributes each on a new line
+    - (x) Indent using spaces
+    - Indentation size: 4

--- a/sportstracker/src/main/java/de/saring/sportstracker/gui/STApplication.java
+++ b/sportstracker/src/main/java/de/saring/sportstracker/gui/STApplication.java
@@ -4,19 +4,18 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import de.saring.exerciseviewer.core.EVOptions;
+import de.saring.exerciseviewer.gui.EVContext;
+import de.saring.sportstracker.core.STException;
+import de.saring.sportstracker.core.STOptions;
 import de.saring.sportstracker.storage.IStorage;
 import de.saring.sportstracker.storage.XMLStorage;
+import de.saring.util.gui.javafx.WindowBoundsPersistence;
+import de.saring.util.unitcalc.FormatUtils;
 import eu.lestard.easydi.EasyDI;
 import javafx.application.Application;
 import javafx.scene.control.Alert;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
-
-import de.saring.exerciseviewer.gui.EVContext;
-import de.saring.sportstracker.core.STException;
-import de.saring.sportstracker.core.STOptions;
-import de.saring.util.gui.javafx.WindowBoundsPersistence;
-import de.saring.util.unitcalc.FormatUtils;
 
 /**
  * This is the main class of SportsTracker which starts the entire application.

--- a/sportstracker/src/main/resources/i18n/SportsTracker.properties
+++ b/sportstracker/src/main/resources/i18n/SportsTracker.properties
@@ -2,9 +2,9 @@
 # SportsTracker resources for english language (default)
 # 
 # Version: SportsTracker 7.5.0
-# Last update: 2017/12/10
+# Last update: 2018/02/10
 # 
-# (C) 2017, Stefan Saring
+# (C) 2018, Stefan Saring
 #####################################################################
 
 application.title=SportsTracker
@@ -442,7 +442,7 @@ st.dlg.options.smoothed_charts.text=Show smoothed charts (average filter)
 st.dlg.about.title=About SportsTracker
 st.dlg.about.description.text=A tool for tracking your sport activities and viewing exercise files.\nIt's written for the Java platform and uses the JavaFX toolkit.
 st.dlg.about.license.text=License: GNU General Public License (GPL), Version 2
-st.dlg.about.copyright.text=(C) 2017 Stefan Saring
+st.dlg.about.copyright.text=(C) 2018 Stefan Saring
 st.dlg.about.title.authors=Authors
 st.dlg.about.title.translators=Translators
 st.dlg.about.authors.text=\

--- a/sportstracker/src/main/resources/i18n/SportsTracker_de.properties
+++ b/sportstracker/src/main/resources/i18n/SportsTracker_de.properties
@@ -2,9 +2,9 @@
 # SportsTracker resources for german language
 # 
 # Version: SportsTracker 7.5.0
-# Last update: 2017/12/10
+# Last update: 2018/02/10
 # 
-# (C) 2017, Stefan Saring
+# (C) 2018, Stefan Saring
 # Translated by Stefan Saring <projects@saring.de>
 #####################################################################
 

--- a/sportstracker/src/test/java/de/saring/sportstracker/data/EntryFilterTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/data/EntryFilterTest.java
@@ -1,10 +1,10 @@
 package de.saring.sportstracker.data;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * This class contains all unit tests for the EntryFilter class.
@@ -18,7 +18,7 @@ public class EntryFilterTest {
     /**
      * This method initializes the environment for testing.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
 
         // create a sport type list with 2 sport types with 2 sport subtypes in each

--- a/sportstracker/src/test/java/de/saring/sportstracker/data/EquipmentTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/data/EquipmentTest.java
@@ -1,9 +1,9 @@
 package de.saring.sportstracker.data;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * This class contains all unit tests for the Equipment class.

--- a/sportstracker/src/test/java/de/saring/sportstracker/data/ExerciseListTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/data/ExerciseListTest.java
@@ -1,13 +1,13 @@
 package de.saring.sportstracker.data;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.regex.PatternSyntaxException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This class contains all unit tests for the ExerciseList class.
@@ -22,7 +22,7 @@ public class ExerciseListTest {
     /**
      * This method initializes the environment for testing.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
 
         // create a sport type list with 2 sport types with 2 sport subtypes in each
@@ -533,27 +533,22 @@ public class ExerciseListTest {
     }
 
     /**
-     * Test of getEntriesForFilter(): use of regular expression "cise [0-2" with syntax error => ArgumentException needs
-     * to be thrown.
+     * Test of getEntriesForFilter(): use of regular expression "cise [0-2" with syntax error => PatternSyntaxException
+     * needs to be thrown.
      */
     @Test
     public void testGetEntriesForFilter21() {
 
-        try {
-            EntryFilter filter = new EntryFilter();
-            filter.setDateStart(LocalDate.of(2003, 1, 1));
-            filter.setDateEnd(LocalDate.of(2003, 12, 31));
-            filter.setSportType(null);
-            filter.setSportSubType(null);
-            filter.setIntensity(null);
-            filter.setCommentSubString("cise [0-2");
-            filter.setRegularExpressionMode(true);
+        EntryFilter filter = new EntryFilter();
+        filter.setDateStart(LocalDate.of(2003, 1, 1));
+        filter.setDateEnd(LocalDate.of(2003, 12, 31));
+        filter.setSportType(null);
+        filter.setSportSubType(null);
+        filter.setIntensity(null);
+        filter.setCommentSubString("cise [0-2");
+        filter.setRegularExpressionMode(true);
 
-            list.getEntriesForFilter(filter);
-            fail("The expected System.ArgumentException was not thown!");
-        } catch (PatternSyntaxException pse) {
-        } catch (Exception e) {
-            fail("The expected System.ArgumentException was not thown!");
-        }
+        assertThrows(PatternSyntaxException.class, () ->
+            list.getEntriesForFilter(filter));
     }
 }

--- a/sportstracker/src/test/java/de/saring/sportstracker/data/NoteListTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/data/NoteListTest.java
@@ -1,14 +1,14 @@
 package de.saring.sportstracker.data;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.regex.PatternSyntaxException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class contains all unit tests for the NoteList class.
@@ -22,7 +22,7 @@ public class NoteListTest {
     /**
      * Setup of test data.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
 
         // create a new list with some test content
@@ -219,25 +219,20 @@ public class NoteListTest {
     }
 
     /**
-     * Tests for getEntriesForFilter(): use of regular expression "ote [0-2" with syntax error => ArgumentException 
+     * Tests for getEntriesForFilter(): use of regular expression "ote [0-2" with syntax error => PatternSyntaxException
      * needs to be thrown.
      */
     @Test
     public void testGetEntriesForFilter11() {
 
-        try {
-            EntryFilter filter = new EntryFilter();
-            filter.setDateStart(LocalDate.of(2003, 1, 1));
-            filter.setDateEnd(LocalDate.of(2003, 12, 31));
-            filter.setEntryType(EntryFilter.EntryType.NOTE);
-            filter.setCommentSubString("cise [0-2");
-            filter.setRegularExpressionMode(true);
+        EntryFilter filter = new EntryFilter();
+        filter.setDateStart(LocalDate.of(2003, 1, 1));
+        filter.setDateEnd(LocalDate.of(2003, 12, 31));
+        filter.setEntryType(EntryFilter.EntryType.NOTE);
+        filter.setCommentSubString("cise [0-2");
+        filter.setRegularExpressionMode(true);
 
-            list.getEntriesForFilter(filter);
-            fail("The expected System.ArgumentException was not thown!");
-        } catch (PatternSyntaxException pse) {
-        } catch (Exception e) {
-            fail("The expected System.ArgumentException was not thown!");
-        }
+        assertThrows(PatternSyntaxException.class, () ->
+            list.getEntriesForFilter(filter));
     }
 }

--- a/sportstracker/src/test/java/de/saring/sportstracker/data/SportSubTypeTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/data/SportSubTypeTest.java
@@ -1,9 +1,9 @@
 package de.saring.sportstracker.data;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * This class contains all unit tests for the SportSubType class.

--- a/sportstracker/src/test/java/de/saring/sportstracker/data/SportTypeTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/data/SportTypeTest.java
@@ -1,10 +1,10 @@
 package de.saring.sportstracker.data;
 
 import javafx.scene.paint.Color;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This class contains all unit tests for the SportType class.
@@ -18,7 +18,7 @@ public class SportTypeTest {
     /**
      * This method initializes the environment for testing.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
 
         // create a new sport type with some test content

--- a/sportstracker/src/test/java/de/saring/sportstracker/data/WeightListTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/data/WeightListTest.java
@@ -1,14 +1,14 @@
 package de.saring.sportstracker.data;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.regex.PatternSyntaxException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class contains all unit tests for the WeightList class.
@@ -22,7 +22,7 @@ public class WeightListTest {
     /**
      * Setup of test data.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
 
         // create a new list with some test content
@@ -218,25 +218,20 @@ public class WeightListTest {
     }
 
     /**
-     * Tests for getEntriesForFilter(): use of regular expression "ote [0-2" with syntax error => ArgumentException 
+     * Tests for getEntriesForFilter(): use of regular expression "ote [0-2" with syntax error => PatternSyntaxException
      * needs to be thrown.
      */
     @Test
     public void testGetEntriesForFilter11() {
 
-        try {
-            EntryFilter filter = new EntryFilter();
-            filter.setDateStart(LocalDate.of(2003, 1, 1));
-            filter.setDateEnd(LocalDate.of(2003, 12, 31));
-            filter.setEntryType(EntryFilter.EntryType.WEIGHT);
-            filter.setCommentSubString("cise [0-2");
-            filter.setRegularExpressionMode(true);
+        EntryFilter filter = new EntryFilter();
+        filter.setDateStart(LocalDate.of(2003, 1, 1));
+        filter.setDateEnd(LocalDate.of(2003, 12, 31));
+        filter.setEntryType(EntryFilter.EntryType.WEIGHT);
+        filter.setCommentSubString("cise [0-2");
+        filter.setRegularExpressionMode(true);
 
-            list.getEntriesForFilter(filter);
-            fail("The expected System.ArgumentException was not thown!");
-        } catch (PatternSyntaxException pse) {
-        } catch (Exception e) {
-            fail("The expected System.ArgumentException was not thown!");
-        }
+        assertThrows(PatternSyntaxException.class, () ->
+            list.getEntriesForFilter(filter));
     }
 }

--- a/sportstracker/src/test/java/de/saring/sportstracker/data/statistic/StatisticCalculatorTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/data/statistic/StatisticCalculatorTest.java
@@ -4,12 +4,12 @@ import de.saring.sportstracker.data.Exercise;
 import de.saring.sportstracker.data.SportSubType;
 import de.saring.sportstracker.data.SportType;
 import de.saring.util.data.IdObjectList;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This class contains all unit tests for the StatisticCalculator class.
@@ -24,7 +24,7 @@ public class StatisticCalculatorTest {
     /**
      * This method initializes the environment for testing.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
 
         // create one sport type with one subtype
@@ -106,8 +106,8 @@ public class StatisticCalculatorTest {
         assertEquals(278 / 2, calculator.getAvgHeartRate());
         assertEquals(2340 / 3, calculator.getAvgCalories());
 
-        assertEquals(0f, calculator.getMinDistance(), 0f);
-        assertEquals(0f, calculator.getMinAvgSpeed(), 0f);
+        assertEquals(0f, calculator.getMinDistance(), 0.001f);
+        assertEquals(0f, calculator.getMinAvgSpeed(), 0.001f);
         assertEquals(2634, calculator.getMinDuration());
         assertEquals(0, calculator.getMinAscent());
         assertEquals(138, calculator.getMinAvgHeartRate());

--- a/sportstracker/src/test/java/de/saring/sportstracker/gui/STDocumentTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/gui/STDocumentTest.java
@@ -1,13 +1,13 @@
 package de.saring.sportstracker.gui;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests of class STDocument/Impl. All the involved components will be
@@ -19,7 +19,7 @@ public class STDocumentTest {
 
     private STDocument document;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         // STContext needs to be mocked
         STContext contextMock = mock(STContext.class);

--- a/sportstracker/src/test/java/de/saring/sportstracker/gui/dialogs/ExerciseViewModelTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/gui/dialogs/ExerciseViewModelTest.java
@@ -1,14 +1,14 @@
 package de.saring.sportstracker.gui.dialogs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import de.saring.sportstracker.data.Equipment;
 import de.saring.sportstracker.data.Exercise;
@@ -25,7 +25,7 @@ public class ExerciseViewModelTest {
 
     private Exercise exercise;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         exercise = new Exercise(123);
         exercise.setDateTime(LocalDateTime.of(2014, 10, 20, 7, 30, 0));

--- a/sportstracker/src/test/java/de/saring/sportstracker/gui/dialogs/FilterViewModelTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/gui/dialogs/FilterViewModelTest.java
@@ -1,13 +1,13 @@
 package de.saring.sportstracker.gui.dialogs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.time.LocalDate;
 
 import de.saring.sportstracker.data.EntryFilter;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import de.saring.sportstracker.data.Equipment;
 import de.saring.sportstracker.data.Exercise;
@@ -23,7 +23,7 @@ public class FilterViewModelTest {
 
     private EntryFilter entryFilter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         entryFilter = new EntryFilter();
         entryFilter.setDateStart(LocalDate.of(2014, 10, 1));

--- a/sportstracker/src/test/java/de/saring/sportstracker/gui/dialogs/NoteViewModelTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/gui/dialogs/NoteViewModelTest.java
@@ -1,10 +1,10 @@
 package de.saring.sportstracker.gui.dialogs;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import de.saring.sportstracker.data.Note;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -18,7 +18,7 @@ public class NoteViewModelTest {
 
     private Note note;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         note = new Note(123);
         note.setDateTime(LocalDateTime.of(2014, 10, 20, 7, 30, 0));

--- a/sportstracker/src/test/java/de/saring/sportstracker/gui/dialogs/PreferencesViewModelTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/gui/dialogs/PreferencesViewModelTest.java
@@ -1,11 +1,11 @@
 package de.saring.sportstracker.gui.dialogs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import de.saring.sportstracker.core.STOptions;
 import de.saring.util.unitcalc.FormatUtils;
@@ -19,7 +19,7 @@ public class PreferencesViewModelTest {
 
     private STOptions options;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         options = new STOptions();
         options.setInitialView(STOptions.View.List);

--- a/sportstracker/src/test/java/de/saring/sportstracker/gui/dialogs/SportTypeViewModelTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/gui/dialogs/SportTypeViewModelTest.java
@@ -4,11 +4,11 @@ import de.saring.sportstracker.data.Equipment;
 import de.saring.sportstracker.data.SportSubType;
 import de.saring.sportstracker.data.SportType;
 import javafx.scene.paint.Color;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests of class SportTypeViewModel.
@@ -19,7 +19,7 @@ public class SportTypeViewModelTest {
 
     private SportType sportType;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         sportType = new SportType(123);
         sportType.setName("Foo Bar");

--- a/sportstracker/src/test/java/de/saring/sportstracker/gui/dialogs/WeightViewModelTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/gui/dialogs/WeightViewModelTest.java
@@ -1,12 +1,12 @@
 package de.saring.sportstracker.gui.dialogs;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import de.saring.sportstracker.data.Weight;
 import de.saring.util.unitcalc.FormatUtils;
@@ -20,7 +20,7 @@ public class WeightViewModelTest {
 
     private Weight weight;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         weight = new Weight(123);
         weight.setDateTime(LocalDateTime.of(2014, 10, 20, 7, 30, 0));

--- a/sportstracker/src/test/java/de/saring/sportstracker/storage/SQLiteExporterTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/storage/SQLiteExporterTest.java
@@ -1,6 +1,6 @@
 package de.saring.sportstracker.storage;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -9,9 +9,9 @@ import java.time.LocalDateTime;
 
 import javafx.scene.paint.Color;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import de.saring.sportstracker.core.STException;
 import de.saring.sportstracker.data.Equipment;
@@ -34,7 +34,7 @@ public class SQLiteExporterTest {
     private STDocument document;
     private SQLiteExporter exporter;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException {
 
         STContext contextMock = mock(STContext.class);
@@ -44,7 +44,7 @@ public class SQLiteExporterTest {
         exporter = new SQLiteExporter(document);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws IOException {
         Files.deleteIfExists(exporter.getDatabasePath());
     }

--- a/sportstracker/src/test/java/de/saring/sportstracker/storage/XMLStorageTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/storage/XMLStorageTest.java
@@ -3,14 +3,14 @@ package de.saring.sportstracker.storage;
 import de.saring.sportstracker.core.STException;
 import de.saring.sportstracker.data.*;
 import de.saring.util.gui.javafx.ColorUtils;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.time.LocalDateTime;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This class contains all unit tests for the XMLStorage class.
@@ -30,7 +30,7 @@ public class XMLStorageTest {
     /**
      * This method initializes the environment for testing.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
         storage = new XMLStorage();
     }
@@ -38,7 +38,7 @@ public class XMLStorageTest {
     /**
      * This method removes all temporary files after all tests were done.
      */
-    @AfterClass
+    @AfterAll
     public static void cleanUpFinal() {
         deleteFileIfExists(EXERCISES_WRITETEST_XML);
         deleteFileIfExists(SPORTTYPES_WRITETEST_XML);
@@ -135,11 +135,8 @@ public class XMLStorageTest {
 
         // read invalid sporttype list from XML
         // => an STException needs to be thrown
-        try {
-            storage.readSportTypeList("misc/testdata/sport-types-invalid.xml");
-            fail();
-        } catch (STException se) {
-        }
+        assertThrows(STException.class, () ->
+            storage.readSportTypeList("misc/testdata/sport-types-invalid.xml"));
     }
 
     /**
@@ -299,21 +296,15 @@ public class XMLStorageTest {
 
         // read invalid exercise list from XML
         // => an STException needs to be thrown
-        try {
-            storage.readExerciseList("misc/testdata/exercises-invalid.xml", sportTypeList);
-            fail();
-        } catch (STException se) {
-        }
+        assertThrows(STException.class, () ->
+            storage.readExerciseList("misc/testdata/exercises-invalid.xml", sportTypeList));
 
         // read valid exercise list from XML but remove the referenced equipment
         // from the sport type configuration before
         // => an STException needs to be thrown
         sportTypeList.getByID(1).getEquipmentList().removeByID(2);
-        try {
-            storage.readExerciseList("misc/testdata/exercises-valid.xml", sportTypeList);
-            fail();
-        } catch (STException se) {
-        }
+        assertThrows(STException.class, () ->
+            storage.readExerciseList("misc/testdata/exercises-valid.xml", sportTypeList));
     }
 
     /**
@@ -354,11 +345,8 @@ public class XMLStorageTest {
 
         // read invalid note list from XML
         // => an STException needs to be thrown
-        try {
-            storage.readNoteList("misc/testdata/notes-invalid.xml");
-            fail();
-        } catch (STException se) {
-        }
+        assertThrows(STException.class, () ->
+            storage.readNoteList("misc/testdata/notes-invalid.xml"));
     }
 
     /**
@@ -422,11 +410,8 @@ public class XMLStorageTest {
 
         // read invalid weight list from XML
         // => an STException needs to be thrown
-        try {
-            storage.readWeightList("misc/testdata/weights-invalid.xml");
-            fail();
-        } catch (STException se) {
-        }
+        assertThrows(STException.class, () ->
+            storage.readWeightList("misc/testdata/weights-invalid.xml"));
     }
 
     /**
@@ -455,7 +440,7 @@ public class XMLStorageTest {
      */
     private void checkWeightListContent(WeightList weightList) {
         assertNotNull(weightList);
-        assertEquals(weightList.size(), 3);
+        assertEquals(3, weightList.size());
 
         Weight weight1 = weightList.getByID(1);
         assertEquals(1, weight1.getId());

--- a/st-exerciseviewer/pom.xml
+++ b/st-exerciseviewer/pom.xml
@@ -14,7 +14,7 @@
     </parent>
 
     <properties>
-        <kotlin.version>1.2.0</kotlin.version>
+        <kotlin.version>1.2.21</kotlin.version>
     </properties>
 
     <dependencies>

--- a/st-exerciseviewer/src/test/java/de/saring/exerciseviewer/parser/impl/GarminFitParserTest.java
+++ b/st-exerciseviewer/src/test/java/de/saring/exerciseviewer/parser/impl/GarminFitParserTest.java
@@ -1,9 +1,10 @@
 package de.saring.exerciseviewer.parser.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.time.LocalDateTime;
@@ -12,8 +13,8 @@ import java.util.TimeZone;
 
 import de.saring.exerciseviewer.core.EVException;
 import de.saring.exerciseviewer.data.Lap;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import de.saring.exerciseviewer.data.EVExercise;
 import de.saring.exerciseviewer.parser.AbstractExerciseParser;
@@ -34,7 +35,7 @@ public class GarminFitParserTest {
     /**
      * This method initializes the environment for testing.
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         // change locale/timezone to Germany (files recorded there), otherwise the datetime comparision fails
         Locale.setDefault(Locale.GERMANY);
@@ -46,20 +47,23 @@ public class GarminFitParserTest {
     /**
      * This method must fail on parsing an exercise file which doesn't exists.
      */
-    @Test(expected = EVException.class)
+    @Test
     public void testParseExerciseMissingFile() throws EVException {
-        parser.parseExercise("missing-file.fit");
+        assertThrows(EVException.class, () ->
+            parser.parseExercise("missing-file.fit"));
     }
 
     /**
      * This method tests the parser with an FIT file which contains only settings data,
      * no exercise data. An exception needs to be thrown.
      */
-    @Test(expected = EVException.class)
+    @Test
     public void testParseExerciseSettingsFile() throws EVException {
         final String FILENAME = "misc/testdata/garmin-fit/Settings.fit";
         assertTrue(new File(FILENAME).exists());
-        parser.parseExercise(FILENAME);
+
+        assertThrows(EVException.class, () ->
+                parser.parseExercise(FILENAME));
     }
 
     /**

--- a/st-exerciseviewer/src/test/java/de/saring/exerciseviewer/parser/impl/HAC4TURParserTest.java
+++ b/st-exerciseviewer/src/test/java/de/saring/exerciseviewer/parser/impl/HAC4TURParserTest.java
@@ -3,13 +3,13 @@ package de.saring.exerciseviewer.parser.impl;
 import de.saring.exerciseviewer.core.EVException;
 import de.saring.exerciseviewer.data.EVExercise;
 import de.saring.exerciseviewer.parser.AbstractExerciseParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This class contains all unit tests for the HAC4TURParser class.
@@ -26,7 +26,7 @@ public class HAC4TURParserTest {
     /**
      * This method initializes the environment for testing.
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         parser = new HAC4TURParser();
     }
@@ -36,11 +36,8 @@ public class HAC4TURParserTest {
      */
     @Test
     public void testParseExerciseMissingFile() {
-        try {
-            parser.parseExercise("missing-file.tur");
-            fail("Parse of the missing file must fail ...");
-        } catch (EVException e) {
-        }
+        assertThrows(EVException.class, () ->
+            parser.parseExercise("missing-file.tur"));
     }
 
     /**

--- a/st-exerciseviewer/src/test/java/de/saring/exerciseviewer/parser/impl/PolarF11RawParserTest.java
+++ b/st-exerciseviewer/src/test/java/de/saring/exerciseviewer/parser/impl/PolarF11RawParserTest.java
@@ -3,15 +3,15 @@ package de.saring.exerciseviewer.parser.impl;
 import de.saring.exerciseviewer.core.EVException;
 import de.saring.exerciseviewer.data.EVExercise;
 import de.saring.exerciseviewer.parser.AbstractExerciseParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This class contains all unit tests for the PolarF6RawParser class using a F11
@@ -31,7 +31,7 @@ public class PolarF11RawParserTest {
     /**
      * This method initializes the environment for testing.
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         parser = new PolarF6RawParser();
     }
@@ -41,11 +41,8 @@ public class PolarF11RawParserTest {
      */
     @Test
     public void testParseExerciseMissingFile() {
-        try {
-            parser.parseExercise("missing-file.frd");
-            fail("Parse of the missing file must fail ...");
-        } catch (EVException e) {
-        }
+        assertThrows(EVException.class, () ->
+                parser.parseExercise("missing-file.frd"));
     }
 
     /**

--- a/st-exerciseviewer/src/test/java/de/saring/exerciseviewer/parser/impl/PolarF6RawParserTest.java
+++ b/st-exerciseviewer/src/test/java/de/saring/exerciseviewer/parser/impl/PolarF6RawParserTest.java
@@ -3,15 +3,15 @@ package de.saring.exerciseviewer.parser.impl;
 import de.saring.exerciseviewer.core.EVException;
 import de.saring.exerciseviewer.data.EVExercise;
 import de.saring.exerciseviewer.parser.AbstractExerciseParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This class contains all unit tests for the PolarF6RawParser class.
@@ -30,7 +30,7 @@ public class PolarF6RawParserTest {
     /**
      * This method initializes the environment for testing.
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         parser = new PolarF6RawParser();
     }
@@ -40,11 +40,8 @@ public class PolarF6RawParserTest {
      */
     @Test
     public void testParseExerciseMissingFile() {
-        try {
-            parser.parseExercise("missing-file.frd");
-            fail("Parse of the missing file must fail ...");
-        } catch (EVException e) {
-        }
+        assertThrows(EVException.class, () ->
+                parser.parseExercise("missing-file.frd"));
     }
 
     /**

--- a/st-exerciseviewer/src/test/java/de/saring/exerciseviewer/parser/impl/PolarHsrParserTest.java
+++ b/st-exerciseviewer/src/test/java/de/saring/exerciseviewer/parser/impl/PolarHsrParserTest.java
@@ -1,15 +1,15 @@
 package de.saring.exerciseviewer.parser.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
 
 import de.saring.exerciseviewer.core.EVException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import de.saring.exerciseviewer.data.EVExercise;
 import de.saring.exerciseviewer.parser.AbstractExerciseParser;
@@ -31,7 +31,7 @@ public class PolarHsrParserTest {
     /**
      * This method initializes the environment for testing.
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         parser = new PolarHsrRawParser();
     }
@@ -41,11 +41,8 @@ public class PolarHsrParserTest {
      */
     @Test
     public void testParseExerciseMissingFile() {
-        try {
-            parser.parseExercise("missing-file.srd");
-            fail("Parse of the missing file must fail ...");
-        } catch (EVException e) {
-        }
+        assertThrows(EVException.class, () ->
+                parser.parseExercise("missing-file.srd"));
     }
 
     /**

--- a/st-exerciseviewer/src/test/java/de/saring/exerciseviewer/parser/impl/PolarSRawParserTest.java
+++ b/st-exerciseviewer/src/test/java/de/saring/exerciseviewer/parser/impl/PolarSRawParserTest.java
@@ -1,16 +1,16 @@
 package de.saring.exerciseviewer.parser.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
 
 import de.saring.exerciseviewer.core.EVException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import de.saring.exerciseviewer.data.EVExercise;
 import de.saring.exerciseviewer.parser.AbstractExerciseParser;
@@ -30,7 +30,7 @@ public class PolarSRawParserTest {
     /**
      * This method initializes the environment for testing.
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         parser = new PolarSRawParser();
     }
@@ -40,11 +40,8 @@ public class PolarSRawParserTest {
      */
     @Test
     public void testParseExerciseMissingFile() {
-        try {
-            parser.parseExercise("missing-file.srd");
-            fail("Parse of the missing file must fail ...");
-        } catch (EVException e) {
-        }
+        assertThrows(EVException.class, () ->
+                parser.parseExercise("missing-file.srd"));
     }
 
     /**

--- a/st-exerciseviewer/src/test/java/de/saring/exerciseviewer/parser/impl/TimexPwxParserTest.java
+++ b/st-exerciseviewer/src/test/java/de/saring/exerciseviewer/parser/impl/TimexPwxParserTest.java
@@ -3,13 +3,13 @@ package de.saring.exerciseviewer.parser.impl;
 import de.saring.exerciseviewer.core.EVException;
 import de.saring.exerciseviewer.data.EVExercise;
 import de.saring.exerciseviewer.parser.AbstractExerciseParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This class contains all unit tests for the TimexPwxParser class.
@@ -32,7 +32,7 @@ public class TimexPwxParserTest {
     /**
      * This method initializes the environment for testing.
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         parser = new TimexPwxParser();
     }
@@ -42,11 +42,8 @@ public class TimexPwxParserTest {
      */
     @Test
     public void testParseExerciseMissingFile() {
-        try {
-            parser.parseExercise("missing-file.srd");
-            fail("Parse of the missing file must fail ...");
-        } catch (EVException e) {
-        }
+        assertThrows(EVException.class, () ->
+                parser.parseExercise("missing-file.srd"));
     }
 
     /**
@@ -129,7 +126,7 @@ public class TimexPwxParserTest {
         assertEquals((0 * 60) + 12, exercise.getHeartRateLimits().get(5).getTimeAbove().intValue());
 
         // check lap data (first, two from middle and last only)
-        float delta = 0;
+        float delta = 0.001f;
         assertEquals(exercise.getLapList().size(), 12);
         assertEquals(exercise.getLapList().get(0).getTimeSplit(), 10 * ((0 * 60 * 60) + (3 * 60) + 45) + 4);
         assertNull(exercise.getLapList().get(0).getHeartRateSplit());

--- a/st-exerciseviewer/src/test/kotlin/de/saring/exerciseviewer/parser/ExerciseParserFactoryTest.kt
+++ b/st-exerciseviewer/src/test/kotlin/de/saring/exerciseviewer/parser/ExerciseParserFactoryTest.kt
@@ -5,10 +5,10 @@ import de.saring.exerciseviewer.parser.impl.PolarSRawParser
 import de.saring.exerciseviewer.parser.impl.TimexPwxParser
 import de.saring.exerciseviewer.parser.impl.garminfit.GarminFitParser
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 
 /**
  * This class contains all unit tests for the ExerciseParserFactory class.
@@ -46,11 +46,8 @@ class ExerciseParserFactoryTest {
         parser = ExerciseParserFactory.getParser("exercise1.ped")
         assertEquals("de.saring.exerciseviewer.parser.impl.PolarPedParser", parser.javaClass.name)
 
-        try {
-            // this parser is unknown, must fail
+        assertThrows(EVException::class.java) {
             ExerciseParserFactory.getParser("exercises/exercise1.xyz")
-            fail("Parser for suffix xyz must not be found!")
-        } catch (e: EVException) {
         }
     }
 }

--- a/st-exerciseviewer/src/test/kotlin/de/saring/exerciseviewer/parser/impl/GarminTcxParserTest.kt
+++ b/st-exerciseviewer/src/test/kotlin/de/saring/exerciseviewer/parser/impl/GarminTcxParserTest.kt
@@ -3,8 +3,8 @@ package de.saring.exerciseviewer.parser.impl
 import de.saring.exerciseviewer.core.EVException
 import de.saring.exerciseviewer.data.EVExercise
 import de.saring.exerciseviewer.parser.ExerciseParser
-import org.junit.Assert.*
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
 /**
@@ -20,9 +20,11 @@ class GarminTcxParserTest {
     /**
      * This method must fail on parsing an exercise file which doesn't exists.
      */
-    @Test(expected = EVException::class)
+    @Test
     fun testParseExerciseMissingFile() {
-        parser.parseExercise("misc/testdata/garmin-tcx/unknown-file.tcx")
+        assertThrows(EVException::class.java) {
+            parser.parseExercise("misc/testdata/garmin-tcx/unknown-file.tcx")
+        }
     }
 
     /**

--- a/st-exerciseviewer/src/test/kotlin/de/saring/exerciseviewer/parser/impl/PolarHRMParserTest.kt
+++ b/st-exerciseviewer/src/test/kotlin/de/saring/exerciseviewer/parser/impl/PolarHRMParserTest.kt
@@ -4,8 +4,8 @@ import de.saring.exerciseviewer.core.EVException
 import de.saring.exerciseviewer.data.EVExercise
 import de.saring.exerciseviewer.parser.ExerciseParser
 
-import org.junit.Assert.*
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
 
 import java.time.LocalDateTime
 
@@ -22,9 +22,11 @@ class PolarHRMParserTest {
     /**
      * This method must fail on parsing an exerise file which doesn't exists.
      */
-    @Test(expected = EVException::class)
+    @Test
     fun testParseExerciseMissingFile() {
-        parser.parseExercise("misc/testdata/sample-123.hrm")
+        assertThrows(EVException::class.java) {
+            parser.parseExercise("misc/testdata/sample-123.hrm")
+        }
     }
 
     /**

--- a/st-exerciseviewer/src/test/kotlin/de/saring/exerciseviewer/parser/impl/PolarPedParserTest.kt
+++ b/st-exerciseviewer/src/test/kotlin/de/saring/exerciseviewer/parser/impl/PolarPedParserTest.kt
@@ -3,8 +3,8 @@ package de.saring.exerciseviewer.parser.impl
 import de.saring.exerciseviewer.core.EVException
 import de.saring.exerciseviewer.data.EVExercise
 
-import org.junit.Assert.*
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
 
 import java.time.LocalDateTime
 
@@ -24,9 +24,11 @@ class PolarPedParserTest {
     /**
      * This method must fail on parsing an exerise file which doesn't exists.
      */
-    @Test(expected = EVException::class)
+    @Test
     fun testParseExerciseMissingFile() {
-        parser.parseExercise("misc/testdata/missing-file.ped")
+        assertThrows(EVException::class.java) {
+            parser.parseExercise("misc/testdata/missing-file.ped")
+        }
     }
 
     /**

--- a/st-exerciseviewer/src/test/kotlin/de/saring/exerciseviewer/parser/impl/PolarRS200SDParserTest.kt
+++ b/st-exerciseviewer/src/test/kotlin/de/saring/exerciseviewer/parser/impl/PolarRS200SDParserTest.kt
@@ -3,8 +3,8 @@ package de.saring.exerciseviewer.parser.impl
 import de.saring.exerciseviewer.core.EVException
 import de.saring.exerciseviewer.data.EVExercise
 import de.saring.exerciseviewer.parser.ExerciseParser
-import org.junit.Assert.*
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
 
 import java.time.LocalDateTime
 
@@ -21,9 +21,11 @@ class PolarRS200SDParserTest {
     /**
      * This method must fail on parsing an exercise file which doesn't exists.
      */
-    @Test(expected = EVException::class)
+    @Test
     fun testParseExerciseMissingFile() {
-        parser.parseExercise("misc/testdata/rs200sd-sample-123.xml")
+        assertThrows(EVException::class.java) {
+            parser.parseExercise("misc/testdata/rs200sd-sample-123.xml")
+        }
     }
 
     /**

--- a/st-exerciseviewer/src/test/kotlin/de/saring/exerciseviewer/parser/impl/SmartsyncCSVParserTest.kt
+++ b/st-exerciseviewer/src/test/kotlin/de/saring/exerciseviewer/parser/impl/SmartsyncCSVParserTest.kt
@@ -4,8 +4,8 @@ import de.saring.exerciseviewer.core.EVException
 import de.saring.exerciseviewer.data.EVExercise
 import de.saring.exerciseviewer.parser.ExerciseParser
 
-import org.junit.Assert.*
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
 
 import java.time.LocalDateTime
 
@@ -23,9 +23,11 @@ class SmartsyncCSVParserTest {
     /**
      * This method must fail on parsing an exerise file which doesn't exists.
      */
-    @Test(expected = EVException::class)
+    @Test
     fun testParseExerciseMissingFile() {
-        parser.parseExercise("misc/testdata/sample-123.csv")
+        assertThrows(EVException::class.java) {
+            parser.parseExercise("misc/testdata/sample-123.csv")
+        }
     }
 
     /**

--- a/st-exerciseviewer/src/test/kotlin/de/saring/exerciseviewer/parser/impl/TopoGrafixGpxParserTest.kt
+++ b/st-exerciseviewer/src/test/kotlin/de/saring/exerciseviewer/parser/impl/TopoGrafixGpxParserTest.kt
@@ -4,8 +4,8 @@ import de.saring.exerciseviewer.core.EVException
 import de.saring.exerciseviewer.data.EVExercise
 import de.saring.exerciseviewer.parser.ExerciseParser
 
-import org.junit.Assert.*
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
 
 import java.time.LocalDateTime
 
@@ -22,9 +22,11 @@ class TopoGrafixGpxParserTest {
     /**
      * This method must fail on parsing an exerise file which doesn't exists.
      */
-    @Test(expected = EVException::class)
+    @Test
     fun testParseExerciseMissingFile() {
-        parser.parseExercise("misc/testdata/gpx/unknown-file.gpx")
+        assertThrows(EVException::class.java) {
+            parser.parseExercise("misc/testdata/gpx/unknown-file.gpx")
+        }
     }
 
     /**

--- a/st-util/src/test/java/de/saring/util/Date310UtilsTest.java
+++ b/st-util/src/test/java/de/saring/util/Date310UtilsTest.java
@@ -1,14 +1,13 @@
 package de.saring.util;
 
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.temporal.WeekFields;
 import java.util.Calendar;
 import java.util.Date;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class contains all unit tests for the Date310Utils class.

--- a/st-util/src/test/java/de/saring/util/StringUtilsTest.java
+++ b/st-util/src/test/java/de/saring/util/StringUtilsTest.java
@@ -1,11 +1,11 @@
 package de.saring.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class contains all unit tests for the StringUtils class.

--- a/st-util/src/test/java/de/saring/util/ValidationUtilsTest.java
+++ b/st-util/src/test/java/de/saring/util/ValidationUtilsTest.java
@@ -1,13 +1,13 @@
 package de.saring.util;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This class contains all unit tests for the ValidationUtilsTest class.
@@ -21,7 +21,7 @@ public class ValidationUtilsTest {
     /**
      * Set default locale to GERMAN, because the number validation tests are locale dependent.
      */
-    @BeforeClass
+    @BeforeAll
     public static void initLocale() {
         defaultLocale = Locale.getDefault();
         Locale.setDefault(Locale.GERMAN);
@@ -30,7 +30,7 @@ public class ValidationUtilsTest {
     /**
      * Reset default locale to previous value.
      */
-    @AfterClass
+    @AfterAll
     public static void resetLocale() {
         Locale.setDefault(defaultLocale);
     }

--- a/st-util/src/test/java/de/saring/util/data/IdDateObjectListTest.java
+++ b/st-util/src/test/java/de/saring/util/data/IdDateObjectListTest.java
@@ -1,15 +1,16 @@
 package de.saring.util.data;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests of class IdDateObjectList.
@@ -23,7 +24,7 @@ public class IdDateObjectListTest {
      */
     private IdDateObjectList<DateNameObject> list;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         list = new IdDateObjectList<>();
         list.set(new DateNameObject(1, LocalDateTime.of(2009, 02, 05, 21, 30, 0), "one"));
@@ -94,37 +95,42 @@ public class IdDateObjectListTest {
     /**
      * Test of method clearAndAddAll(). Must fail when null is passed.
      */
-    @Test(expected = NullPointerException.class)
+    @Test
     public void clearAndAddAllNull() {
-        list.clearAndAddAll(null);
+        assertThrows(NullPointerException.class, () ->
+                list.clearAndAddAll(null));
     }
 
     /**
      * Test of method clearAndAddAll(). Must fail when an entry contain an invalid ID.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void clearAndAddAllInvalidId() {
 
         ArrayList<DateNameObject> tempEntries = new ArrayList<>();
         list.set(new DateNameObject(5, LocalDateTime.of(2009, 02, 05, 21, 30, 0), "five"));
-        list.set(new DateNameObject(-6, LocalDateTime.of(2009, 02, 01, 21, 30, 0), "minus six"));
-        list.clearAndAddAll(tempEntries);
+
+
+        assertThrows(IllegalArgumentException.class, () ->
+                list.set(new DateNameObject(-6, LocalDateTime.of(2009, 02, 01, 21, 30, 0), "minus six")));
     }
 
     /**
      * Test of set(): must fail when the entry is null.
      */
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testSetNull() {
-        list.set(null);
+        assertThrows(NullPointerException.class, () ->
+                list.set(null));
     }
 
     /**
      * Test of set(): must fail when date is null.
      */
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testSetDateNull() {
-        list.set(new DateNameObject(4, null, "four"));
+        assertThrows(NullPointerException.class, () ->
+            list.set(new DateNameObject(4, null, "four")));
     }
 
     /**
@@ -158,19 +164,21 @@ public class IdDateObjectListTest {
     /**
      * Test of getEntriesInDateRange(): must fail when one of the dates is null.
      */
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testGetEntriesInDateRangeNull() {
-        list.getEntriesInDateRange(LocalDate.now(), null);
+        assertThrows(NullPointerException.class, () ->
+            list.getEntriesInDateRange(LocalDate.now(), null));
     }
 
     /**
      * Test of getEntriesInDateRange(): must fail when the begin date ist after end date.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetEntriesInDateRangeInvalidRange() {
-        list.getEntriesInDateRange(
-                LocalDate.of(2009, 12, 11),
-                LocalDate.of(2009, 11, 11));
+        assertThrows(IllegalArgumentException.class, () ->
+            list.getEntriesInDateRange(
+                    LocalDate.of(2009, 12, 11),
+                    LocalDate.of(2009, 11, 11)));
     }
 
     /**

--- a/st-util/src/test/java/de/saring/util/data/IdObjectListChangeListenerTest.java
+++ b/st-util/src/test/java/de/saring/util/data/IdObjectListChangeListenerTest.java
@@ -1,12 +1,16 @@
 package de.saring.util.data;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 import java.util.ArrayList;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for IdObjectListChangeListener usage in IdObjectList. Test for a
@@ -19,7 +23,7 @@ public class IdObjectListChangeListenerTest {
     private IdObjectList<DummyIdObject> idObjectList;
     private IdObjectListChangeListener listenerMock;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         idObjectList = new IdObjectList<>();
         idObjectList.set(new DummyIdObject(1));

--- a/st-util/src/test/java/de/saring/util/data/IdObjectListTest.java
+++ b/st-util/src/test/java/de/saring/util/data/IdObjectListTest.java
@@ -1,11 +1,11 @@
 package de.saring.util.data;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests of class IdObjectList.
@@ -19,7 +19,7 @@ public class IdObjectListTest {
      */
     private IdObjectList<NameObject> list;
 
-    @Before
+    @BeforeEach
     public void setUp() {
 
         // create a new list with some content
@@ -48,11 +48,8 @@ public class IdObjectListTest {
         assertEquals("one", list.getAt(0).getName());
         assertEquals("three", list.getAt(2).getName());
 
-        try {
-            list.getAt(3);
-            fail("Must fail, index is not valid...");
-        } catch (IndexOutOfBoundsException e) {
-        }
+        assertThrows(IndexOutOfBoundsException.class, () ->
+            list.getAt(3));
     }
 
     /**
@@ -92,17 +89,19 @@ public class IdObjectListTest {
     /**
      * Test of set method set() of class IdObjectList: must fail on null.
      */
-    @Test(expected = NullPointerException.class)
+    @Test
     public void setNull() {
-        list.set(null);
+        assertThrows(NullPointerException.class, () ->
+            list.set(null));
     }
 
     /**
      * Test of set method set() of class IdObjectList: must fail when ID = 0.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void setIdZero() {
-        list.set(new NameObject(0, "Null"));
+        assertThrows(IllegalArgumentException.class, () ->
+            list.set(new NameObject(0, "Null")));
     }
 
     /**
@@ -125,21 +124,24 @@ public class IdObjectListTest {
     /**
      * Test of method clearAndAddAll(). Must fail when null is passed.
      */
-    @Test(expected = NullPointerException.class)
+    @Test
     public void clearAndAddAllNull() {
-        list.clearAndAddAll(null);
+        assertThrows(NullPointerException.class, () ->
+            list.clearAndAddAll(null));
     }
 
     /**
      * Test of method clearAndAddAll(). Must fail when an entry contain an invalid ID.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void clearAndAddAllInvalidId() {
 
         ArrayList<NameObject> tempEntries = new ArrayList<>();
         tempEntries.add(new NameObject(5, "five"));
         tempEntries.add(new NameObject(-6, "minus six"));
-        list.clearAndAddAll(tempEntries);
+
+        assertThrows(IllegalArgumentException.class, () ->
+            list.clearAndAddAll(tempEntries));
     }
 
     /**

--- a/st-util/src/test/java/de/saring/util/data/IdObjectTest.java
+++ b/st-util/src/test/java/de/saring/util/data/IdObjectTest.java
@@ -1,9 +1,9 @@
 package de.saring.util.data;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests of class IdObject.

--- a/st-util/src/test/java/de/saring/util/gui/javafx/BindingUtilsToggleGroupTest.java
+++ b/st-util/src/test/java/de/saring/util/gui/javafx/BindingUtilsToggleGroupTest.java
@@ -5,11 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import javafx.application.Application;
+import javafx.application.Platform;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.control.RadioButton;
 import javafx.scene.control.ToggleGroup;
 
+import javafx.stage.Stage;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -19,9 +23,6 @@ import org.junit.jupiter.api.Test;
  *
  * @author Stefan Saring
  */
-// TODO JUnit4 test was executed by @RunWith(JfxRunner.class), does not work in JUnit5 anymore
-// TODO initialize JavaFX toolkit before test execution
-@Disabled
 public class BindingUtilsToggleGroupTest {
 
     private enum Options {
@@ -35,8 +36,20 @@ public class BindingUtilsToggleGroupTest {
 
     private ObjectProperty<Options> optionsProperty;
 
+    /**
+     * Initializes the JavaFX toolkit before test execution. Otherwise the test will fail with
+     * "java.lang.IllegalStateException: Toolkit not initialized".
+     */
+    @BeforeAll
+    static void initJavaFXToolKit() {
+
+        new Thread(() -> {
+            Application.launch(DummyFXApplication.class);
+        }).start();
+    }
+
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         rbOptionA = new RadioButton("Option A");
         rbOptionA.setUserData(Options.OptionA);
 
@@ -83,5 +96,15 @@ public class BindingUtilsToggleGroupTest {
 
         assertThrows(IllegalArgumentException.class, () ->
             BindingUtils.bindToggleGroupToProperty(tgOptions, optionsProperty));
+    }
+
+    /**
+     * Dummy application for initializing the JavaFX toolkit.
+     */
+    public static class DummyFXApplication extends Application {
+
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+        }
     }
 }

--- a/st-util/src/test/java/de/saring/util/gui/javafx/BindingUtilsToggleGroupTest.java
+++ b/st-util/src/test/java/de/saring/util/gui/javafx/BindingUtilsToggleGroupTest.java
@@ -1,26 +1,27 @@
 package de.saring.util.gui.javafx;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.control.RadioButton;
 import javafx.scene.control.ToggleGroup;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import de.saxsys.javafx.test.JfxRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for ToggleGroup related methods in class BindingUtils.
  *
  * @author Stefan Saring
  */
-@RunWith(JfxRunner.class)
+// TODO JUnit4 test was executed by @RunWith(JfxRunner.class), does not work in JUnit5 anymore
+// TODO initialize JavaFX toolkit before test execution
+@Disabled
 public class BindingUtilsToggleGroupTest {
 
     private enum Options {
@@ -34,7 +35,7 @@ public class BindingUtilsToggleGroupTest {
 
     private ObjectProperty<Options> optionsProperty;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         rbOptionA = new RadioButton("Option A");
         rbOptionA.setUserData(Options.OptionA);
@@ -75,10 +76,12 @@ public class BindingUtilsToggleGroupTest {
      * Test of bindToggleGroupToProperty(): One radio button has no user data set,
      * the binding must throw an IllegalArgumentException.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testBindToggleGroupToPropertyMissingUserData() {
 
         rbOptionB.setUserData(null);
-        BindingUtils.bindToggleGroupToProperty(tgOptions, optionsProperty);
+
+        assertThrows(IllegalArgumentException.class, () ->
+            BindingUtils.bindToggleGroupToProperty(tgOptions, optionsProperty));
     }
 }

--- a/st-util/src/test/java/de/saring/util/gui/javafx/ColorUtilsTest.java
+++ b/st-util/src/test/java/de/saring/util/gui/javafx/ColorUtilsTest.java
@@ -1,9 +1,9 @@
 package de.saring.util.gui.javafx;
 
 import javafx.scene.paint.Color;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests of class ColorUtils.

--- a/st-util/src/test/java/de/saring/util/gui/javafx/SpeedToStringConverterTest.java
+++ b/st-util/src/test/java/de/saring/util/gui/javafx/SpeedToStringConverterTest.java
@@ -1,13 +1,13 @@
 package de.saring.util.gui.javafx;
 
 import de.saring.util.unitcalc.FormatUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit tests of class SpeedToStringConverter.
@@ -21,7 +21,7 @@ public class SpeedToStringConverterTest {
     /**
      * Set default locale to GERMAN, because the number validation tests are locale dependent.
      */
-    @BeforeClass
+    @BeforeAll
     public static void initLocale() {
         defaultLocale = Locale.getDefault();
         Locale.setDefault(Locale.GERMAN);
@@ -30,7 +30,7 @@ public class SpeedToStringConverterTest {
     /**
      * Reset default locale to previous value.
      */
-    @AfterClass
+    @AfterAll
     public static void resetLocale() {
         Locale.setDefault(defaultLocale);
     }

--- a/st-util/src/test/java/de/saring/util/gui/javafx/TimeInSecondsToStringConverterTest.java
+++ b/st-util/src/test/java/de/saring/util/gui/javafx/TimeInSecondsToStringConverterTest.java
@@ -1,9 +1,9 @@
 package de.saring.util.gui.javafx;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import de.saring.util.unitcalc.FormatUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests of class TimeInSecondsToStringConverter.

--- a/st-util/src/test/java/de/saring/util/gui/javafx/TimeToStringConverterTest.java
+++ b/st-util/src/test/java/de/saring/util/gui/javafx/TimeToStringConverterTest.java
@@ -1,11 +1,12 @@
 package de.saring.util.gui.javafx;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests of class TimeToStringConverter.
@@ -42,24 +43,27 @@ public class TimeToStringConverterTest {
     /**
      * Tests of method fromString(): conversion must fail for invalid time values.
      */
-    @Test(expected = DateTimeParseException.class)
+    @Test
     public void testFromStringFailedInvalidTime() {
-        CONVERTER.fromString("24:62");
+        assertThrows(DateTimeParseException.class, () ->
+            CONVERTER.fromString("24:62"));
     }
 
     /**
      * Tests of method fromString(): conversion must fail for no time values.
      */
-    @Test(expected = DateTimeParseException.class)
+    @Test
     public void testFromStringFailedNoTime() {
-        CONVERTER.fromString("foo:bar");
+        assertThrows(DateTimeParseException.class, () ->
+            CONVERTER.fromString("foo:bar"));
     }
 
     /**
      * Tests of method fromString(): conversion must fail when minutes are missing.
      */
-    @Test(expected = DateTimeParseException.class)
+    @Test
     public void testFromStringFailedNoMinutes() {
-        CONVERTER.fromString("10:");
+        assertThrows(DateTimeParseException.class, () ->
+            CONVERTER.fromString("10:"));
     }
 }

--- a/st-util/src/test/java/de/saring/util/unitcalc/CalculationUtilsTest.java
+++ b/st-util/src/test/java/de/saring/util/unitcalc/CalculationUtilsTest.java
@@ -1,8 +1,8 @@
 package de.saring.util.unitcalc;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This class contains all unit tests for the CalculationUtils class.
@@ -16,7 +16,7 @@ public class CalculationUtilsTest {
      */
     @Test
     public void testCalculateDistance() {
-        assertEquals(0f, CalculationUtils.calculateDistance(0, 0), 0f);
+        assertEquals(0f, CalculationUtils.calculateDistance(0, 0));
         assertEquals(20f, CalculationUtils.calculateDistance(20, 3600), 0.01f);
         assertEquals(49.165054f, CalculationUtils.calculateDistance((float) 35.3, 5014), 0.0001f);
     }
@@ -26,7 +26,7 @@ public class CalculationUtilsTest {
      */
     @Test
     public void testCalculateAvgSpeed() {
-        assertEquals(Float.NaN, CalculationUtils.calculateAvgSpeed(0, 0), 0f);
+        assertEquals(Float.NaN, CalculationUtils.calculateAvgSpeed(0, 0));
         assertEquals(20f, CalculationUtils.calculateAvgSpeed(20, 3600), 0.01f);
         assertEquals(35.3f, CalculationUtils.calculateAvgSpeed((float) 49.165054, 5014), 0.00001f);
     }

--- a/st-util/src/test/java/de/saring/util/unitcalc/ConvertUtilsTest.java
+++ b/st-util/src/test/java/de/saring/util/unitcalc/ConvertUtilsTest.java
@@ -1,8 +1,8 @@
 package de.saring.util.unitcalc;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This class contains all unit tests for the ConvertUtils class.
@@ -17,7 +17,7 @@ public class ConvertUtilsTest {
     @Test
     public void testConvertMiles2Kilometer() {
         // test double version
-        assertEquals(ConvertUtils.convertMiles2Kilometer(0.0d), 0.0d, 0d);
+        assertEquals(0d, ConvertUtils.convertMiles2Kilometer(0d));
         assertEquals(ConvertUtils.convertMiles2Kilometer(145.3d), 233.83768320000004d, 0.000001d);
 
         // test int version
@@ -31,8 +31,8 @@ public class ConvertUtilsTest {
     @Test
     public void testConvertKilometer2Miles() {
         // test double version
-        assertEquals(ConvertUtils.convertKilometer2Miles(0d, false), 0d, 0d);
-        assertEquals(ConvertUtils.convertKilometer2Miles(0d, true), 0d, 0d);
+        assertEquals(ConvertUtils.convertKilometer2Miles(0d, false), 0d, 0.001d);
+        assertEquals(ConvertUtils.convertKilometer2Miles(0d, true), 0d, 0.001d);
         assertEquals(ConvertUtils.convertKilometer2Miles(145.3d, false), 90.2852342320846d, 0.00001d);
         assertEquals(ConvertUtils.convertKilometer2Miles(145.3d, true), 90.285d, 0.00001d);
 
@@ -64,7 +64,7 @@ public class ConvertUtilsTest {
      */
     @Test
     public void testConvertMeterPerSecond2KilometerPerHour() {
-        assertEquals(0f, ConvertUtils.convertMeterPerSecond2KilometerPerHour(0f), 0f);
+        assertEquals(0f, ConvertUtils.convertMeterPerSecond2KilometerPerHour(0f));
         assertEquals(3.6f, ConvertUtils.convertMeterPerSecond2KilometerPerHour(1f), 0.001f);
         assertEquals(44.64f, ConvertUtils.convertMeterPerSecond2KilometerPerHour(12.4f), 0.001f);
     }
@@ -74,7 +74,7 @@ public class ConvertUtilsTest {
      */
     @Test
     public void testConvertKilogram2Lbs() {
-        assertEquals(0, ConvertUtils.convertKilogram2Lbs(0), 0.0001d);
+        assertEquals(0, ConvertUtils.convertKilogram2Lbs(0));
         assertEquals(2.2046d, ConvertUtils.convertKilogram2Lbs(1), 0.0001d);
         assertEquals(165.852058d, ConvertUtils.convertKilogram2Lbs(75.23d), 0.0001d);
     }
@@ -84,7 +84,7 @@ public class ConvertUtilsTest {
      */
     @Test
     public void testConvertLbs2Kilogram() {
-        assertEquals(0, ConvertUtils.convertLbs2Kilogram(0), 0.0001d);
+        assertEquals(0, ConvertUtils.convertLbs2Kilogram(0));
         assertEquals(1, ConvertUtils.convertLbs2Kilogram(2.2046d), 0.0001d);
         assertEquals(34.12410d, ConvertUtils.convertLbs2Kilogram(75.23d), 0.0001d);
     }
@@ -94,7 +94,7 @@ public class ConvertUtilsTest {
      */
     @Test
     public void testConvertSemicircle2Degree() {
-        assertEquals(0d, ConvertUtils.convertSemicircle2Degree(0), 0d);
+        assertEquals(0d, ConvertUtils.convertSemicircle2Degree(0), 0.001d);
         assertEquals(51.054392d, ConvertUtils.convertSemicircle2Degree(609102623), 0.0001d);
         assertEquals(-51.054392d, ConvertUtils.convertSemicircle2Degree(-609102623), 0.0001d);
     }

--- a/st-util/src/test/java/de/saring/util/unitcalc/FormatUtilsTest.java
+++ b/st-util/src/test/java/de/saring/util/unitcalc/FormatUtilsTest.java
@@ -1,12 +1,12 @@
 package de.saring.util.unitcalc;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This class contains all unit tests for the ConvertUtils class.
@@ -16,12 +16,19 @@ import static org.junit.Assert.assertNull;
 public class FormatUtilsTest {
 
     /**
-     * Thes tests needs to use the English locale, results look different for
-     * other.
+     * Thes tests needs to use the English locale, results look different for other.
      */
-    @Before
-    public void setUp() {
+    @BeforeAll
+    static void setUp() {
         Locale.setDefault(Locale.ENGLISH);
+    }
+
+    /**
+     * Restore default Locale afterwards.
+     */
+    @AfterAll
+    static void tearDown() {
+        Locale.setDefault(Locale.getDefault());
     }
 
     /**

--- a/st-util/src/test/java/de/saring/util/unitcalc/XmlBeanStorageTest.java
+++ b/st-util/src/test/java/de/saring/util/unitcalc/XmlBeanStorageTest.java
@@ -1,6 +1,7 @@
 package de.saring.util.unitcalc;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -8,8 +9,8 @@ import java.io.Serializable;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import de.saring.util.XmlBeanStorage;
 
@@ -25,7 +26,7 @@ public class XmlBeanStorageTest {
     /**
      * Removes the test files after test execution.
      */
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         Files.deleteIfExists(Paths.get(BEAN_FILENAME));
     }
@@ -54,19 +55,22 @@ public class XmlBeanStorageTest {
      * Tests the method loadBean(): Loading must fail with a FileNotFoundException because
      * the file does not exists.
      */
-    @Test(expected = FileNotFoundException.class)
+    @Test
     public void testLoadBeanFailedFileNotFound() throws Exception {
-        XmlBeanStorage.loadBean(BEAN_FILENAME);
+        assertThrows(FileNotFoundException.class, () ->
+            XmlBeanStorage.loadBean(BEAN_FILENAME));
     }
 
     /**
      * Tests the method saveBean(): Saving must fail with a IOException because the file
      * can't be created (there's a directory with the same name).
      */
-    @Test(expected = IOException.class)
+    @Test
     public void testSaveBeanFailedCreateFile() throws Exception {
         Files.createDirectory(Paths.get(BEAN_FILENAME));
-        XmlBeanStorage.saveBean(new TestBean(), BEAN_FILENAME);
+
+        assertThrows(IOException.class, () ->
+            XmlBeanStorage.saveBean(new TestBean(), BEAN_FILENAME));
     }
 
     /**


### PR DESCRIPTION
Migration reasons:

* JUnit 4 API will get deprecated in the long term
* allows use of lambdas in the JUnit API
* better exception handling and validation possibilities