### PR TITLE
Worn and replaced Equipment can be set to 'not in use'

### DIFF
--- a/leafletmap/README.md
+++ b/leafletmap/README.md
@@ -12,7 +12,7 @@ Both the LeafletMap component and the demo application are written in Kotlin.
 #### Dependencies and used libraries
 
 * Java SE 11 (tested with AdoptOpenJDK 11)
-* OpenJFX 11.0.2
+* OpenJFX 12.0.1
     * Homepage: https://openjfx.io/
     * License: GPL v2 + Classpath Exception
 * Kotlin 1.3.30
@@ -59,6 +59,7 @@ Both the LeafletMap component and the demo application are written in Kotlin.
 LeafletMap 1.0.4:
 
 * Updated to Kotlin 1.3.30
+* Updated to OpenJFX 12.0.1
 
 LeafletMap 1.0.3:
 

--- a/leafletmap/pom.xml
+++ b/leafletmap/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <javafx.version>11.0.2</javafx.version>
+        <javafx.version>12.0.1</javafx.version>
         <kotlin.version>1.3.30</kotlin.version>
     </properties>
     

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,33 @@
             <groupId>org.controlsfx</groupId>
             <artifactId>controlsfx</artifactId>
             <version>11.0.0</version>
+            <exclusions>
+                <!-- exclude all OpenJFX dependencies because SportsTracker uses a newer OpenJFX version -->
+                <exclusion>
+                    <groupId>org.openjfx</groupId>
+                    <artifactId>javafx-base</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.openjfx</groupId>
+                    <artifactId>javafx-base</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.openjfx</groupId>
+                    <artifactId>javafx-graphics</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.openjfx</groupId>
+                    <artifactId>javafx-controls</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.openjfx</groupId>
+                    <artifactId>javafx-media</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.openjfx</groupId>
+                    <artifactId>javafx-web</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Common test dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <application.mainClass>de.saring.sportstracker.STMain</application.mainClass>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.version>1.3.30</kotlin.version>
-        <javafx.version>12</javafx.version>
+        <javafx.version>12.0.1</javafx.version>
         <junit.version>5.4.0</junit.version>
     </properties>
     

--- a/sportstracker/docs/CHANGES.txt
+++ b/sportstracker/docs/CHANGES.txt
@@ -16,6 +16,13 @@ v7.6.1:
    (checked on each application start after 30 seconds)
  - Exercise Dialog: bugfix for issue #206, the average speed input now displays
    the proper unit for the speed mode of the selected sport type
+ - Equipment of sport types can now be set to 'not in use', e.g. for worn shoes
+   - the Exercise dialog does not display the outdated equipment for selection
+     anymore => the user must not search in long lists anymore
+   - Sport Type Dialog: the user can toggle the 'not in use' state for each
+     equipment
+   - the outdated equipment is still present in older Exercise entries, Filter
+     and Statistic dialogs
 - Module st-util:
   - ported most classes and unit tests from Java to Kotlin, so there is less
     code, it's null safe, and fewer tests are needed

--- a/sportstracker/docs/CHANGES.txt
+++ b/sportstracker/docs/CHANGES.txt
@@ -5,7 +5,7 @@ v7.6.1:
  SportsTracker changes:
  - updated to JDK 12 (tested with AdoptOpenJDK 12)
    - use of new switch expression features (less code)
- - updated to JavaFX 12 (OpenJFX)
+ - updated to JavaFX / OpenJFX 12.0.1
  - updated ControlsFX to version 11.0.0
  - updated JUnit 5 to version 5.4.0
  - Kotlin language can now be used in all SportsTracker Maven modules

--- a/sportstracker/docs/I18N.txt
+++ b/sportstracker/docs/I18N.txt
@@ -48,6 +48,8 @@ History of resource changes for each release
 SportsTracker 7.6.1:
 
 - st.main.info.update_available (new)
+- st.dlg.sporttype.toggle_equipment_use.Action.text (new)
+- st.dlg.sporttype.equipment_not_in_use.suffix (new)
 
 SportsTracker 7.6.0:
 

--- a/sportstracker/docs/README.txt
+++ b/sportstracker/docs/README.txt
@@ -174,7 +174,8 @@ For each sport type you need to create at least one subtype. Subtype examples
 for cycling are "MTB tour", "MTB race", "Road tour" and so on. If subtypes
 do not make sense for your sport type just create a subtype called "default".
 You can also define a list of equipment for a sport type (optional), e.g.
-specific bikes for cycling or shoes for running.
+specific bikes for cycling or shoes for running. Worn and outdated equipment
+can be set to 'not in use' state, then it can't be selected anymore.
 
 After that it's possible to add and edit exercises. In the exercise dialog
 you need to specify the date, the sport type, the subtype and the intensity.

--- a/sportstracker/docs/README.txt
+++ b/sportstracker/docs/README.txt
@@ -406,7 +406,7 @@ All user interfaces are defined in FXML by using the JavaFX Scene Builder 9.x.
 
 The SportsTracker project uses the following libraries:
 
-  - OpenJFX 12 (https://openjfx.io/)
+  - OpenJFX 12.0.1 (https://openjfx.io/)
       License: GPL v2 + Classpath Exception
   - EasyDI 0.3.0 (https://github.com/lestard/EasyDI)
       Includes: javax.inject-1.jar

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -12,10 +12,9 @@ Deactivated Equipment:
   - extend XML storage and unit test (DONE)
   - extend Exercise dialog
     - don't display Equipments with notInUse=true in selection combobox (DONE),
-      except for existing exercises where such a Equipment has been selected before
-      => Implemented, but does not work as expected!!!
+      except for existing exercises where such a Equipment has been selected before (DONE)
   - extend Sport Type dialog, user can select whether an Equipment is not in use (add editable table column?)
-
+  - add to ChangeLog + doc?
 
 Reminder for Notes:
 - useful for planning events or tasks (e.g. for training or maintenance)

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -1,6 +1,8 @@
 SportsTracker-TODO
 ==================
 
+Unexpected application crashes when switching between SportsTracker/ExerciseViewer and other apps!
+
 Deactivated Equipment:
 - Goal: deactivate equipment which is not in use anymore (e.g. worn-out-shoes)
   - it's not available for selection in Exercise dialog anymore (except it has been set)
@@ -10,10 +12,11 @@ Deactivated Equipment:
   - add attribute Equipment#notInUse (default = false) (DONE)
   - add attribute to XML schema and test files (DONE)
   - extend XML storage and unit test (DONE)
-  - extend Sport Type dialog, user can select whether an Equipment is not in use (add editable table column?)
   - extend Exercise dialog
-    - don't display Equipments with notInUse=true in selection combobox,
+    - don't display Equipments with notInUse=true in selection combobox (DONE),
       except for existing exercises where such a Equipment has been selected before
+      => Implemented, but does not work as expected!!!
+  - extend Sport Type dialog, user can select whether an Equipment is not in use (add editable table column?)
 
 
 Reminder for Notes:

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -1,10 +1,6 @@
 SportsTracker-TODO
 ==================
 
-Unexpected application crashes when switching between SportsTracker/ExerciseViewer with opened dialog and other apps!
-- Crashes occur with OpenJFX 12.0.1, 13-ea+8 and 11.0.2, seems to be a new issue after updating to JDK 12
-- I've created an bug issue on OpenJFX GitHub page: https://github.com/javafxports/openjdk-jfx/issues/480
-
 Deactivated Equipment:
 - Goal: deactivate equipment which is not in use anymore (e.g. worn-out-shoes)
   - it's not available for selection in Exercise dialog anymore (except it has been set)

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -1,6 +1,21 @@
 SportsTracker-TODO
 ==================
 
+Deactivated Equipment:
+- Goal: deactivate equipment which is not in use anymore (e.g. worn-out-shoes)
+  - it's not available for selection in Exercise dialog anymore (except it has been set)
+  - still shown in the Filter or Overview dialogs
+- TODOs
+  - create branch
+  - add attribute Equipment#notInUse (default = false) (DONE)
+  - add attribute to XML schema and test files (DONE)
+  - extend XML storage and unit test (DONE)
+  - extend Sport Type dialog, user can select whether an Equipment is not in use (add editable table column?)
+  - extend Exercise dialog
+    - don't display Equipments with notInUse=true in selection combobox,
+      except for existing exercises where such a Equipment has been selected before
+
+
 Reminder for Notes:
 - useful for planning events or tasks (e.g. for training or maintenance)
 - Add row to Note Dialog below the date and time:

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -1,21 +1,6 @@
 SportsTracker-TODO
 ==================
 
-Deactivated Equipment:
-- Goal: deactivate equipment which is not in use anymore (e.g. worn-out-shoes)
-  - it's not available for selection in Exercise dialog anymore (except it has been set)
-  - still shown in the Filter or Overview dialogs
-- TODOs
-  - create branch
-  - add attribute Equipment#notInUse (default = false) (DONE)
-  - add attribute to XML schema and test files (DONE)
-  - extend XML storage and unit test (DONE)
-  - extend Exercise dialog
-    - don't display Equipments with notInUse=true in selection combobox (DONE),
-      except for existing exercises where such a Equipment has been selected before (DONE)
-  - extend Sport Type dialog, user can select whether an Equipment is not in use (add editable table column?)
-  - add to ChangeLog + doc?
-
 Reminder for Notes:
 - useful for planning events or tasks (e.g. for training or maintenance)
 - Add row to Note Dialog below the date and time:

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -1,7 +1,9 @@
 SportsTracker-TODO
 ==================
 
-Unexpected application crashes when switching between SportsTracker/ExerciseViewer and other apps!
+Unexpected application crashes when switching between SportsTracker/ExerciseViewer with opened dialog and other apps!
+- Crashes occur with OpenJFX 12.0.1, 13-ea+8 and 11.0.2, seems to be a new issue after updating to JDK 12
+- I've created an bug issue on OpenJFX GitHub page: https://github.com/javafxports/openjdk-jfx/issues/480
 
 Deactivated Equipment:
 - Goal: deactivate equipment which is not in use anymore (e.g. worn-out-shoes)

--- a/sportstracker/misc/testdata/sport-types-valid.xml
+++ b/sportstracker/misc/testdata/sport-types-valid.xml
@@ -32,6 +32,7 @@
             <equipment>
 				<id>2</id>
 				<name>Cannondale R800</name>
+				<not-in-use>true</not-in-use>
             </equipment>
         </equipment-list>
 	</sport-type>

--- a/sportstracker/src/main/java/de/saring/sportstracker/data/Equipment.java
+++ b/sportstracker/src/main/java/de/saring/sportstracker/data/Equipment.java
@@ -54,7 +54,7 @@ public final class Equipment extends IdObject implements Nameable, Cloneable {
         sBuilder.append(this.getClass().getName()).append(":\n");
         sBuilder.append(" [id=").append(this.getId()).append("\n");
         sBuilder.append("  name=").append(this.name).append("\n");
-        sBuilder.append("  notInUse=").append(this.name).append("]\n");
+        sBuilder.append("  notInUse=").append(this.notInUse).append("]\n");
         return sBuilder.toString();
     }
 

--- a/sportstracker/src/main/java/de/saring/sportstracker/data/Equipment.java
+++ b/sportstracker/src/main/java/de/saring/sportstracker/data/Equipment.java
@@ -18,6 +18,11 @@ public final class Equipment extends IdObject implements Nameable, Cloneable {
     private String name;
 
     /**
+     * Flag whether this equipment is not in use anymore (e.g. worn out shoes).
+     */
+    private boolean notInUse = false;
+
+    /**
      * Standard c'tor.
      *
      * @param id the ID of the object
@@ -35,12 +40,21 @@ public final class Equipment extends IdObject implements Nameable, Cloneable {
         this.name = name;
     }
 
+    public boolean isNotInUse() {
+        return notInUse;
+    }
+
+    public void setNotInUse(boolean notInUse) {
+        this.notInUse = notInUse;
+    }
+
     @Override
     public String toString() {
         StringBuilder sBuilder = new StringBuilder();
         sBuilder.append(this.getClass().getName()).append(":\n");
         sBuilder.append(" [id=").append(this.getId()).append("\n");
-        sBuilder.append("  name=").append(this.name).append("]\n");
+        sBuilder.append("  name=").append(this.name).append("\n");
+        sBuilder.append("  notInUse=").append(this.name).append("]\n");
         return sBuilder.toString();
     }
 

--- a/sportstracker/src/main/java/de/saring/sportstracker/gui/dialogs/ExerciseDialogController.java
+++ b/sportstracker/src/main/java/de/saring/sportstracker/gui/dialogs/ExerciseDialogController.java
@@ -6,6 +6,7 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -353,8 +354,12 @@ public class ExerciseDialogController extends AbstractDialogController {
 
             selectedSportType.getSportSubTypeList().forEach(sportSubType ->
                     cbSportSubtype.getItems().add(sportSubType));
-            selectedSportType.getEquipmentList().forEach(equipment ->
-                    cbEquipment.getItems().add(equipment));
+
+            // add all active equipments or if the equipment is set in the exercise (even if notInUse has been set)
+            Equipment selectedEquipment = exerciseViewModel.equipment.get();
+            cbEquipment.getItems().addAll(selectedSportType.getEquipmentList().stream()
+                    .filter(equipment -> !equipment.isNotInUse() || equipment.equals(selectedEquipment))
+                    .collect(Collectors.toList()));
 
             // label for average speed needs to show the unit for the sport types speed mode
             laAvgSpeed.setText(context.getResources().getString("st.dlg.exercise.avg_speed.text",

--- a/sportstracker/src/main/java/de/saring/sportstracker/gui/dialogs/SportTypeDialogController.java
+++ b/sportstracker/src/main/java/de/saring/sportstracker/gui/dialogs/SportTypeDialogController.java
@@ -19,6 +19,7 @@ import javafx.scene.control.ButtonType;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ColorPicker;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.TextField;
 import javafx.stage.Window;
@@ -72,6 +73,8 @@ public class SportTypeDialogController extends AbstractDialogController {
     private Button btEquipmentEdit;
     @FXML
     private Button btEquipmentDelete;
+    @FXML
+    private Button btEquipmentToggleUse;
 
 
     /** ViewModel of the edited SportType. */
@@ -111,9 +114,11 @@ public class SportTypeDialogController extends AbstractDialogController {
 
     @Override
     protected void setupDialogControls() {
+
         cbSpeedMode.getItems().addAll(List.of(SpeedModeItem.values()));
         liSportSubtypes.setCellFactory(list -> new NameableListCell<>());
-        liEquipments.setCellFactory(list -> new NameableListCell<>());
+        final String notInUseSuffix = context.getResources().getString("st.dlg.sporttype.equipment_not_in_use.suffix");
+        liEquipments.setCellFactory(list -> new EquipmentListCell(notInUseSuffix));
 
         setupBinding();
         setupValidation();
@@ -165,6 +170,7 @@ public class SportTypeDialogController extends AbstractDialogController {
                 liEquipments.getSelectionModel().selectedItemProperty());
         btEquipmentEdit.disableProperty().bind(equipmentSelected);
         btEquipmentDelete.disableProperty().bind(equipmentSelected);
+        btEquipmentToggleUse.disableProperty().bind(equipmentSelected);
     }
 
     /**
@@ -402,6 +408,16 @@ public class SportTypeDialogController extends AbstractDialogController {
     }
 
     /**
+     * Action for toggling the "Not in use" state of the selected equipment.
+     */
+    @FXML
+    private void onToggleEquipmentUse(final ActionEvent event) {
+        final Equipment selectedEquipment = liEquipments.getSelectionModel().getSelectedItem();
+        selectedEquipment.setNotInUse(!selectedEquipment.isNotInUse());
+        updateEquipmentList();
+    }
+
+    /**
      * Displays the add/edit dialog for the specified equipment name (includes
      * error checking and dialog redisplay). The modified equipment will be
      * stored in the sport type.
@@ -491,6 +507,32 @@ public class SportTypeDialogController extends AbstractDialogController {
                     .filter(speedModeItem -> speedMode == speedModeItem.getSpeedMode())
                     .findAny()
                     .orElseThrow(() -> new IllegalArgumentException("Invalid speedMode '" + speedMode + "'!"));
+        }
+    }
+
+    /**
+     * ListCell for the JavaFX ListView control which displays the Equipment items with their 'not in use' state.
+     */
+    private static class EquipmentListCell extends ListCell<Equipment> {
+
+        private final String notInUseSuffix;
+
+        public EquipmentListCell(String notInUseSuffix) {
+            this.notInUseSuffix = notInUseSuffix;
+        }
+
+        @Override
+        protected void updateItem(final Equipment equipment, final boolean empty) {
+            super.updateItem(equipment, empty);
+
+            String cellText = null;
+            if (equipment != null) {
+                cellText = equipment.getName();
+                if (equipment.isNotInUse()) {
+                    cellText += " " + notInUseSuffix;
+                }
+            }
+            setText(cellText);
         }
     }
 }

--- a/sportstracker/src/main/java/de/saring/sportstracker/storage/XMLSportTypeList.java
+++ b/sportstracker/src/main/java/de/saring/sportstracker/storage/XMLSportTypeList.java
@@ -133,6 +133,7 @@ public class XMLSportTypeList {
             eEquipmentList.getChildren("equipment").forEach(eEquipment -> {
                 Equipment equipment = new Equipment(Integer.parseInt(eEquipment.getChildText("id")));
                 equipment.setName(eEquipment.getChildText("name"));
+                equipment.setNotInUse(Boolean.valueOf(eEquipment.getChildText("not-in-use")));
                 sportType.getEquipmentList().set(equipment);
             });
         }
@@ -207,6 +208,7 @@ public class XMLSportTypeList {
                 eEquipmentList.addContent(eEquipment);
                 XMLUtils.addElement(eEquipment, "id", String.valueOf(equipment.getId()));
                 XMLUtils.addElement(eEquipment, "name", equipment.getName());
+                XMLUtils.addElement(eEquipment, "not-in-use", String.valueOf(equipment.isNotInUse()));
             });
         });
 

--- a/sportstracker/src/main/resources/fxml/dialogs/SportTypeDialog.fxml
+++ b/sportstracker/src/main/resources/fxml/dialogs/SportTypeDialog.fxml
@@ -82,6 +82,7 @@
                                 <Button maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#onAddEquipment" text="%st.dlg.sporttype.add_equipment.Action.text" />
                                 <Button fx:id="btEquipmentEdit" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#onEditEquipment" text="%st.dlg.sporttype.edit_equipment.Action.text" />
                                 <Button fx:id="btEquipmentDelete" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#onDeleteEquipment" text="%st.dlg.sporttype.delete_equipment.Action.text" />
+                                <Button fx:id="btEquipmentToggleUse" maxWidth="1.7976931348623157E308" mnemonicParsing="false" onAction="#onToggleEquipmentUse" text="%st.dlg.sporttype.toggle_equipment_use.Action.text" />
                             </children>
                         </VBox>
                     </children>

--- a/sportstracker/src/main/resources/i18n/SportsTracker.properties
+++ b/sportstracker/src/main/resources/i18n/SportsTracker.properties
@@ -2,7 +2,7 @@
 # SportsTracker resources for english language (default)
 #
 # Version: SportsTracker 7.6.1
-# Last update: 2019/02/16
+# Last update: 2019/05/25
 #
 # (C) 2019, Stefan Saring
 #####################################################################
@@ -221,6 +221,8 @@ st.dlg.sporttype.equipment.text=Equipment List (Optional)
 st.dlg.sporttype.add_equipment.Action.text=Add
 st.dlg.sporttype.edit_equipment.Action.text=Edit
 st.dlg.sporttype.delete_equipment.Action.text=Delete
+st.dlg.sporttype.toggle_equipment_use.Action.text=Toggle Use
+st.dlg.sporttype.equipment_not_in_use.suffix=(not in use)
 st.dlg.sporttype.confirm.delete_subtype.title=Delete Sport Subtype
 st.dlg.sporttype.confirm.delete_subtype.text=Do you really want to delete the selected sport subtype?
 st.dlg.sporttype.confirm.delete_subtype_existing.text=There are existing exercises for this sport subtype. These exercises will be deleted too. Do you really want to continue?

--- a/sportstracker/src/main/resources/i18n/SportsTracker_de.properties
+++ b/sportstracker/src/main/resources/i18n/SportsTracker_de.properties
@@ -2,7 +2,7 @@
 # SportsTracker resources for german language
 #
 # Version: SportsTracker 7.6.1
-# Last update: 2019/02/16
+# Last update: 2019/05/25
 #
 # (C) 2019, Stefan Saring
 # Translated by Stefan Saring <projects@saring.de>
@@ -220,6 +220,8 @@ st.dlg.sporttype.equipment.text=Liste der Ausrüstungen (Optional)
 st.dlg.sporttype.add_equipment.Action.text=Hinzufügen
 st.dlg.sporttype.edit_equipment.Action.text=Bearbeiten
 st.dlg.sporttype.delete_equipment.Action.text=Löschen
+st.dlg.sporttype.toggle_equipment_use.Action.text=Nutzung ändern
+st.dlg.sporttype.equipment_not_in_use.suffix=(nicht mehr genutzt)
 st.dlg.sporttype.confirm.delete_subtype.title=Sportunterart löschen
 st.dlg.sporttype.confirm.delete_subtype.text=Möchten Sie wirklich die selektierte Sportunterart löschen?
 st.dlg.sporttype.confirm.delete_subtype_existing.text=Es existieren noch einige Einheiten dieser Sportunterart. Diese würden auch gelöscht werden. Möchten Sie wirklich fortfahren?

--- a/sportstracker/src/main/resources/xml/sport-types.xsd
+++ b/sportstracker/src/main/resources/xml/sport-types.xsd
@@ -98,6 +98,11 @@
 															<xs:documentation>The name of this equipment.</xs:documentation>
 														</xs:annotation>
 													</xs:element>
+													<xs:element name="not-in-use" type="xs:boolean" default="false" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Flag whether this equipment is not in use anymore.</xs:documentation>
+														</xs:annotation>
+													</xs:element>
 												</xs:sequence>
 											</xs:complexType>
 										</xs:element>

--- a/sportstracker/src/test/java/de/saring/sportstracker/data/EquipmentTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/data/EquipmentTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This class contains all unit tests for the Equipment class.
@@ -19,10 +20,12 @@ public class EquipmentTest {
     public void testClone() {
         Equipment eOrg = new Equipment(123);
         eOrg.setName("Equip");
+        eOrg.setNotInUse(true);
 
         Equipment eClone = eOrg.clone();
         assertFalse(eOrg == eClone);
         assertEquals(123, eClone.getId());
         assertEquals("Equip", eClone.getName());
+        assertTrue(eClone.isNotInUse());
     }
 }

--- a/sportstracker/src/test/java/de/saring/sportstracker/storage/XMLStorageTest.java
+++ b/sportstracker/src/test/java/de/saring/sportstracker/storage/XMLStorageTest.java
@@ -95,9 +95,11 @@ public class XMLStorageTest {
         Equipment equipment1_1 = type1.getEquipmentList().getByID(1);
         assertEquals(equipment1_1.getId(), 1);
         assertEquals(equipment1_1.getName(), "Cannondale Jekyll");
+        assertFalse(equipment1_1.isNotInUse());
         Equipment equipment1_2 = type1.getEquipmentList().getByID(2);
         assertEquals(equipment1_2.getId(), 2);
         assertEquals(equipment1_2.getName(), "Cannondale R800");
+        assertTrue(equipment1_2.isNotInUse());
 
         // check sporttype 2
         SportType type2 = sportTypes.getByID(2);


### PR DESCRIPTION
A lot of equipment for a sport type will be not in use anymore (e.g. worn-out-shoes or replaced bikes) as time goes by.
The user can mark such equipment as 'not in use', this equipment will not be available for selection in exercises aynmore. So the user does not have to search in long lists with all the outdated equipment.
The outdated equipment will still be shown for older exercises and in the Filter and Statistics dialogs.