### PR TITLE
ExerciseViewer: added altitude chart to the Track Panel

### DIFF
--- a/sportstracker/docs/CHANGES.txt
+++ b/sportstracker/docs/CHANGES.txt
@@ -29,6 +29,9 @@ v7.6.1:
   - refactoring: moved all time-related functions from class FormatUtils to
     new class TimeUtils
  ExerciseViewer changes:
+ - Track Panel:
+   - display altitude chart below the track map, if altitude is present
+   - display marker in altitude chart for current track position
  - TopoGrafixGpxParser: bugfix for issue #188, GPX import failed if there are
    samples without heartrate data
 

--- a/sportstracker/docs/I18N.txt
+++ b/sportstracker/docs/I18N.txt
@@ -51,6 +51,8 @@ SportsTracker 7.6.1:
 - st.dlg.sporttype.toggle_equipment_use.Action.text (new)
 - st.dlg.sporttype.equipment_not_in_use.suffix (new)
 
+- pv.track.axis.altitude (new)
+
 SportsTracker 7.6.0:
 
 - st.exerciselistview.descent (new)

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -14,7 +14,13 @@ ExerciseViewer Track panel: display altitude graph below the track
   - TrackPanel already displays altitude chart properly (incl. unit conversion and I18N)
   - Diagram Panel is removed when no altitude data available
   - Track position is also displayed in altitude graph, refactoring needed
-- see TODOs in TrackPanelController
+- TODOs
+  - Fill the area below the altitude graph with a light color (as in Diagram Panel)
+  - add to ChangeLog
+
+Exercise Viewer Diagram Panel:
+- use same or no margin for bottom axis when displayed "by distance" as for "by time"
+  => see solution in altitude chart in Track Panel
 
 Reminder for Notes:
 - useful for planning events or tasks (e.g. for training or maintenance)
@@ -142,10 +148,6 @@ Training route/lap support:
 
 ExerciseViewer-TODO
 ===================
-
-Diagram panel:
-- there's no space at the left side when the bottom axis displays "by distance"
-  (between left axis and graph start)
 
 ExerciseParsers:
 - GarminTcxParser:

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -1,6 +1,10 @@
 SportsTracker-TODO
 ==================
 
+Switch back to JDK 11
+- jpackage JEP-343 will not be available before JDK 14
+  -> a working packaging method is needed before, otherwise no release possible
+
 ExerciseViewer Track panel: display altitude graph below the track
 - JFreeChart has to be used due to problems with JavaFX LineChart
   - JavaFX LineChart makes dialog start quite slow, does not support marker lines,
@@ -9,6 +13,7 @@ ExerciseViewer Track panel: display altitude graph below the track
 - Status:
   - TrackPanel already displays altitude chart properly (incl. unit conversion and I18N)
   - Diagram Panel is removed when no altitude data available
+  - Track position is also displayed in altitude graph, refactoring needed
 - see TODOs in TrackPanelController
 
 Reminder for Notes:

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -5,19 +5,6 @@ Switch back to JDK 11
 - jpackage JEP-343 will not be available before JDK 14
   -> a working packaging method is needed before, otherwise no release possible
 
-ExerciseViewer Track panel: display altitude graph below the track
-- JFreeChart has to be used due to problems with JavaFX LineChart
-  - JavaFX LineChart makes dialog start quite slow, does not support marker lines,
-    insufficient styling options etc.
-  - use of JFreeChart provides also a consistent UI with the Diagram panel
-- Status:
-  - TrackPanel already displays altitude chart properly (incl. unit conversion and I18N)
-  - Diagram Panel is removed when no altitude data available
-  - Track position is also displayed in altitude graph, refactoring needed
-- TODOs
-  - Fill the area below the altitude graph with a light color (as in Diagram Panel)
-  - add to ChangeLog
-
 Exercise Viewer Diagram Panel:
 - use same or no margin for bottom axis when displayed "by distance" as for "by time"
   => see solution in altitude chart in Track Panel

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -7,7 +7,7 @@ ExerciseViewer Track panel: display altitude graph below the track
     insufficient styling options etc.
   - use of JFreeChart provides also a consistent UI with the Diagram panel
 - Status:
-  - Diagram Panel with fix height already in TrackPanel (spDiagram)
+  - TrackPanel already displays altitude chart properly (incl. unit conversion and I18N)
   - Diagram Panel is removed when no altitude data available
 - see TODOs in TrackPanelController
 

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -48,6 +48,9 @@ SportsTracker packaging:
   rewritten by using the upcoming jpackager tool (JEP 343)
 - it uses a jpackager-backport for JDK 11, provided by Gluon
 => update the packaging scripts when jpackager is contained in the JDK
+- Alternative: Gluon Client Plugin (bundles GrailVM, OpenJDK an OpenJFX)
+  - currently in beta and for macOS only
+  - https://docs.gluonhq.com/client/
 
 JavaFX Migration:
 - Migration status: completed, Swing is not in use anymore

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -1,6 +1,16 @@
 SportsTracker-TODO
 ==================
 
+ExerciseViewer Track panel: display altitude graph below the track
+- JFreeChart has to be used due to problems with JavaFX LineChart
+  - JavaFX LineChart makes dialog start quite slow, does not support marker lines,
+    insufficient styling options etc.
+  - use of JFreeChart provides also a consistent UI with the Diagram panel
+- Status:
+  - Diagram Panel with fix height already in TrackPanel (spDiagram)
+  - Diagram Panel is removed when no altitude data available
+- see TODOs in TrackPanelController
+
 Reminder for Notes:
 - useful for planning events or tasks (e.g. for training or maintenance)
 - Add row to Note Dialog below the date and time:

--- a/sportstracker/src/main/resources/i18n/SportsTracker.properties
+++ b/sportstracker/src/main/resources/i18n/SportsTracker.properties
@@ -2,7 +2,7 @@
 # SportsTracker resources for english language (default)
 #
 # Version: SportsTracker 7.6.1
-# Last update: 2019/05/25
+# Last update: 2019/06/14
 #
 # (C) 2019, Stefan Saring
 #####################################################################
@@ -601,4 +601,5 @@ pv.track.tooltip.altitude=Altitude
 pv.track.tooltip.heartrate=Heartrate
 pv.track.tooltip.speed=Speed
 pv.track.tooltip.temperature=Temperature
+pv.track.axis.altitude=altitude (%s)
 pv.track.position.text=Position:

--- a/sportstracker/src/main/resources/i18n/SportsTracker_de.properties
+++ b/sportstracker/src/main/resources/i18n/SportsTracker_de.properties
@@ -2,7 +2,7 @@
 # SportsTracker resources for german language
 #
 # Version: SportsTracker 7.6.1
-# Last update: 2019/05/25
+# Last update: 2019/06/14
 #
 # (C) 2019, Stefan Saring
 # Translated by Stefan Saring <projects@saring.de>
@@ -601,3 +601,5 @@ pv.track.tooltip.altitude=Höhe
 pv.track.tooltip.heartrate=Herzfrequenz
 pv.track.tooltip.speed=Geschwindigkeit
 pv.track.tooltip.temperature=Temperatur
+pv.track.axis.altitude=Höhe (%s)
+pv.track.position.text=Position:

--- a/sportstracker/src/main/resources/i18n/SportsTracker_es.properties
+++ b/sportstracker/src/main/resources/i18n/SportsTracker_es.properties
@@ -2,7 +2,7 @@
 # SportsTracker resources for spanish language (default)
 # 
 # Version: SportsTracker 7.0.0
-# Last update: 2015/02/23
+# Last update: 2019/06/14
 # 
 # (C) 2015, Stefan Saring
 # Translated by Asier Urio Larrea <asieriko@gmail.com>
@@ -570,3 +570,4 @@ pv.track.tooltip.heartrate=Frecuencia cardiaca
 pv.track.tooltip.speed=Velocidad
 pv.track.tooltip.temperature=Temperatura
 pv.track.position.text=Posición:
+pv.track.axis.altitude=altitud (%s)

--- a/sportstracker/src/main/resources/i18n/SportsTracker_fr.properties
+++ b/sportstracker/src/main/resources/i18n/SportsTracker_fr.properties
@@ -2,7 +2,7 @@
 # SportsTracker resources for french language
 # 
 # Version: SportsTracker 7.0.0
-# Last update: 2015/02/23
+# Last update: 2019/06/14
 # 
 # (C) 2015, Stefan Saring
 # Translated by Nicolas Ollivier <nicollivier@gmail.com> and
@@ -290,6 +290,7 @@ st.dlg.exercise.error.no_intensity=Vous devez sélectionner une intensité !
 st.dlg.exercise.error.wrong_relation=Il y a un problème entre la distance, la vitesse moyenne et la durée!\nCorriger une valeur sʹil vous plait.
 st.dlg.exercise.error.no_sport_and_subtype=Vous devez sélectoinner une catégorie et une sous-catégorie en premier !
 st.dlg.exercise.error.no_previous_exercise=Il nʹy a pas de commentaires précédents similaires.
+st.dlg.exercise.error.time=Vous devez entrer une heure valide !
 
 st.dlg.hrm_file_open.title=Sélectionner un fichier HRM
 st.dlg.hrm_file_open.filter_all=Tous les fichiers exerciseviewer
@@ -303,6 +304,7 @@ st.dlg.note.time.text=Heure (hh:mm) :
 st.dlg.note.text.text=Texte :
 st.dlg.note.error.date=Vous devez entrer une date valide !
 st.dlg.note.error.no_text=Vous devez entrer un texte !
+st.dlg.note.error.time=Vous devez entrer une heure valide !
 
 # Weight dialog
 st.dlg.weight.title=Éditer un poids
@@ -315,7 +317,7 @@ st.dlg.weight.ok.Action.text=OK
 st.dlg.weight.cancel.Action.text=Annuler
 st.dlg.weight.error.date=Vous devez entrer une date valide !
 st.dlg.weight.error.weight=Vous devez entrer un poids valide !
-
+st.dlg.weight.error.time=Vous devez entrer une heure valide !
 
 # Filter dialog
 st.dlg.filter.title=Filtre des exercices
@@ -591,7 +593,5 @@ pv.track.tooltip.altitude=Altitude
 pv.track.tooltip.heartrate=Fréquence cardiaque
 pv.track.tooltip.speed=Vitesse
 pv.track.tooltip.temperature=Température
+pv.track.axis.altitude=altitude (%s)
 pv.track.position.text=Position :
-st.dlg.exercise.error.time=Vous devez entrer une heure valide !
-st.dlg.weight.error.time=Vous devez entrer une heure valide !
-st.dlg.note.error.time=Vous devez entrer une heure valide !

--- a/sportstracker/src/main/resources/i18n/SportsTracker_ko.properties
+++ b/sportstracker/src/main/resources/i18n/SportsTracker_ko.properties
@@ -2,7 +2,7 @@
 # SportsTracker resources for korean language (default)
 # 
 # Version: SportsTracker 6.1.0
-# Last update: 2014/11/29
+# Last update: 2019/06/14
 # 
 # (C) 2015, Stefan Saring
 # Translated by Tae Young Ko <oscetic@gmail.com>
@@ -572,3 +572,4 @@ pv.track.tooltip.altitude=고도
 pv.track.tooltip.heartrate=심박 수
 pv.track.tooltip.speed=속도
 pv.track.tooltip.temperature=체온
+pv.track.axis.altitude=고도 (%s)

--- a/st-exerciseviewer/src/main/kotlin/de/saring/exerciseviewer/gui/panels/TrackPanelController.kt
+++ b/st-exerciseviewer/src/main/kotlin/de/saring/exerciseviewer/gui/panels/TrackPanelController.kt
@@ -29,6 +29,7 @@ import org.jfree.chart.fx.ChartViewer
 import org.jfree.chart.plot.PlotOrientation
 import org.jfree.chart.plot.ValueMarker
 import org.jfree.chart.plot.XYPlot
+import org.jfree.chart.renderer.xy.XYAreaRenderer
 import org.jfree.data.Range
 import org.jfree.data.xy.XYSeries
 import org.jfree.data.xy.XYSeriesCollection
@@ -73,6 +74,9 @@ class TrackPanelController(
 
     private var spMapViewerTooltip: Tooltip? = null
     private var positionMarkerName: String? = null
+
+    private val colorAltitudeAxis = java.awt.Color(255, 30, 30)
+    private val colorAltitudePlot = java.awt.Color(255, 30, 30, 128)
 
     private var altitudeGraphMarker: ValueMarker? = null
     private val colorAltitudeGraphMarker = java.awt.Color(110, 110, 120)
@@ -133,10 +137,19 @@ class TrackPanelController(
             val plotAltitude = chartAltitude.plot as XYPlot
 
             // use custom axis (both) with fixed ranges to avoid altitude to start with 0 and to avoid empty space on end of the distance axis
-            plotAltitude.rangeAxis = FixedRangeNumberAxis(
+            val axisAltitude = FixedRangeNumberAxis(
                     getAltitudeAxisTitle(), Range(sAltitude.minY, sAltitude.maxY), true)
+            plotAltitude.rangeAxis = axisAltitude
             plotAltitude.domainAxis = FixedRangeNumberAxis(
                     null, Range(0.0, sAltitude.maxX), false)
+
+            // setup altitude axis and custom area renderer
+            axisAltitude.labelPaint = colorAltitudeAxis
+            axisAltitude.tickLabelPaint = colorAltitudeAxis
+
+            plotAltitude.setRenderer(0, XYAreaRenderer().apply {
+                setSeriesPaint(0, colorAltitudePlot)
+            })
 
             addAltitudeGraphMarker(plotAltitude)
 

--- a/st-exerciseviewer/src/main/kotlin/de/saring/exerciseviewer/gui/panels/TrackPanelController.kt
+++ b/st-exerciseviewer/src/main/kotlin/de/saring/exerciseviewer/gui/panels/TrackPanelController.kt
@@ -11,6 +11,7 @@ import de.saring.leafletmap.MapConfig
 import de.saring.leafletmap.MapLayer
 import de.saring.leafletmap.ScaleControlConfig
 import de.saring.leafletmap.ZoomControlConfig
+import de.saring.util.gui.jfreechart.ChartUtils
 import de.saring.util.unitcalc.TimeUtils
 import de.saring.util.unitcalc.UnitSystem
 import javafx.concurrent.Worker
@@ -20,6 +21,11 @@ import javafx.scene.control.Slider
 import javafx.scene.control.Tooltip
 import javafx.scene.layout.StackPane
 import javafx.scene.layout.VBox
+import org.jfree.chart.ChartFactory
+import org.jfree.chart.fx.ChartViewer
+import org.jfree.chart.plot.PlotOrientation
+import org.jfree.data.xy.XYSeries
+import org.jfree.data.xy.XYSeriesCollection
 import java.util.logging.Level
 import java.util.logging.Logger
 
@@ -103,11 +109,29 @@ class TrackPanelController(
 
         if (document.exercise.recordingMode.isAltitude) {
 
+            val sAltitude = XYSeries("altitude")
+            val dsAltitude = XYSeriesCollection(sAltitude)
+            document.exercise.sampleList.forEach { sample ->
+                sAltitude.add(sample.distance ?: 0, sample.altitude ?: 0)
+            }
 
-//            document.exercise.sampleList.forEach { sample ->
-//                dsAltitude.data.add(XYChart.Data(sample.distance ?: 0, sample.altitude ?: 0))
-//            }
+            // TODO display km distance values instead of meters (or english)
+            // TODO support english units too
+            // TODO I18N for column names
+            // TODO altitude axis has not to start with 0
+            // TODO display marker line for position slider
+            val chartAltitude = ChartFactory.createXYLineChart(null, // Title
+                    null, // Y-axis label
+                    "Altitude", // X-axis label
+                    dsAltitude, // primary dataset
+                    PlotOrientation.VERTICAL, // plot orientation
+                    false, // display legend
+                    false, // display tooltips
+                    false) // URLs
 
+            ChartUtils.customizeChart(chartAltitude)
+            val chartViewer = ChartViewer(chartAltitude)
+            spDiagram.children.addAll(chartViewer)
         }
         else {
             // hide diagram pane when no altitude data present

--- a/st-exerciseviewer/src/main/kotlin/de/saring/exerciseviewer/gui/panels/TrackPanelController.kt
+++ b/st-exerciseviewer/src/main/kotlin/de/saring/exerciseviewer/gui/panels/TrackPanelController.kt
@@ -23,6 +23,7 @@ import javafx.scene.layout.VBox
 import java.util.logging.Level
 import java.util.logging.Logger
 
+
 /**
  * Controller (MVC) class of the "Track" panel, which displays the recorded location data of the exercise (if
  * available) in a map.<br/>
@@ -50,6 +51,9 @@ class TrackPanelController(
     private lateinit var spMapViewer: StackPane
 
     @FXML
+    private lateinit var spDiagram: StackPane
+
+    @FXML
     private lateinit var slPosition: Slider
 
     private var mapView: LeafletMapView? = null
@@ -68,6 +72,7 @@ class TrackPanelController(
         // setup the map viewer if track data is available
         val exercise = document.exercise
         if (exercise.recordingMode.isLocation) {
+            setupAltitudeChart()
             setupMapView()
             setupMapViewerTooltip()
             setupTrackPositionSlider()
@@ -92,6 +97,22 @@ class TrackPanelController(
     private fun setupMapViewerTooltip() {
         spMapViewerTooltip = Tooltip()
         spMapViewerTooltip!!.isAutoHide = true
+    }
+
+    private fun setupAltitudeChart() {
+
+        if (document.exercise.recordingMode.isAltitude) {
+
+
+//            document.exercise.sampleList.forEach { sample ->
+//                dsAltitude.data.add(XYChart.Data(sample.distance ?: 0, sample.altitude ?: 0))
+//            }
+
+        }
+        else {
+            // hide diagram pane when no altitude data present
+            vbTrackViewer.children.remove(spDiagram)
+        }
     }
 
     private fun setupTrackPositionSlider() {

--- a/st-exerciseviewer/src/main/resources/fxml/panels/TrackPanel.fxml
+++ b/st-exerciseviewer/src/main/resources/fxml/panels/TrackPanel.fxml
@@ -7,16 +7,17 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<StackPane fx:id="spTrackPanel" prefHeight="200.0" prefWidth="300.0" stylesheets="@../ExerciseViewer.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="de.saring.exerciseviewer.gui.panels.TrackPanelController">
+<StackPane fx:id="spTrackPanel" prefHeight="300.0" prefWidth="400.0" stylesheets="@../ExerciseViewer.css" xmlns="http://javafx.com/javafx/9" xmlns:fx="http://javafx.com/fxml/1" fx:controller="de.saring.exerciseviewer.gui.panels.TrackPanelController">
     <children>
         <Label text="%pv.track.no_track_data.text">
             <padding>
                 <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />
             </padding>
         </Label>
-        <VBox fx:id="vbTrackViewer" spacing="12.0">
+        <VBox fx:id="vbTrackViewer" prefHeight="308.0" prefWidth="426.0" spacing="12.0">
             <children>
                 <StackPane fx:id="spMapViewer" VBox.vgrow="ALWAYS" />
+                <StackPane fx:id="spDiagram" maxHeight="-Infinity" minHeight="-Infinity" prefHeight="100.0" VBox.vgrow="NEVER" />
                 <HBox alignment="CENTER_LEFT" spacing="12.0">
                     <children>
                         <Label text="%pv.track.position.text" />


### PR DESCRIPTION
This PR is related to issue #207 and it adds a altitude chart to the Track Panel of the ExerciseViewer.
This chart is only displayed when altitude data is available.
The altitude chart also displays the current track position by using a vertical marker line.