### PR TITLE
Added Equipment Usage Dialog

### DIFF
--- a/leafletmap/README.md
+++ b/leafletmap/README.md
@@ -91,7 +91,7 @@ LeafletMap 1.0.1:
 
 #### License
 
-(C) 2019 Stefan Saring
+(C) 2020 Stefan Saring
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/sportstracker/docs/CHANGES.txt
+++ b/sportstracker/docs/CHANGES.txt
@@ -8,6 +8,9 @@ v7.7.1:
    - the usage contains the total distance, duration and dates of first and
      last usage
    - Dialog can be started from the Tools menu
+ - Exercise Dialog: an info message is shown when the user wants to store an
+   exercise without a selected equipment (is often forgotten)
+   - not shown when there is no equipment list for the selected sport type
  ExerciseViewer changes:
  - updated Garmin FIT SDK library to version 21.20.00, provides bugfixes
    and support for newer Garmin devices

--- a/sportstracker/docs/CHANGES.txt
+++ b/sportstracker/docs/CHANGES.txt
@@ -2,6 +2,12 @@ Changelog
 ---------
 
 v7.7.1:
+ SportsTracker changes:
+ - Equipment Usage: added a new dialog which displays the usages of each
+   equipment for a selected sport type
+   - the usage contains the total distance, duration and dates of first and
+     last usage
+   - Dialog can be started from the Tools menu
  ExerciseViewer changes:
  - updated Garmin FIT SDK library to version 21.20.00, provides bugfixes
    and support for newer Garmin devices

--- a/sportstracker/docs/I18N.txt
+++ b/sportstracker/docs/I18N.txt
@@ -47,6 +47,9 @@ History of resource changes for each release
 
 SportsTracker 7.7.1:
 
+- st.view.equipment_usage.Action.text=Equipment (new)
+- st.view.equipment_usage.Action.shortDescription (new)
+
 - st.dlg.equipment_usage.title (new)
 - st.dlg.equipment_usage.sport_type.text (new)
 - st.dlg.equipment_usage.columns.name (new)

--- a/sportstracker/docs/I18N.txt
+++ b/sportstracker/docs/I18N.txt
@@ -39,7 +39,7 @@ resource in one view.
 
 
 Stefan Saring
-2017/10/03
+2020/01/01
 
 
 History of resource changes for each release
@@ -58,6 +58,8 @@ SportsTracker 7.7.1:
 - st.dlg.equipment_usage.columns.first_usage (new)
 - st.dlg.equipment_usage.columns.last_usage (new)
 - st.dlg.equipment_usage.empty (new)
+
+- st.dlg.exercise.info.no_equipment (new)
 
 SportsTracker 7.6.1:
 

--- a/sportstracker/docs/I18N.txt
+++ b/sportstracker/docs/I18N.txt
@@ -45,6 +45,17 @@ Stefan Saring
 History of resource changes for each release
 --------------------------------------------
 
+SportsTracker 7.7.1:
+
+- st.dlg.equipment_usage.title (new)
+- st.dlg.equipment_usage.sport_type.text (new)
+- st.dlg.equipment_usage.columns.name (new)
+- st.dlg.equipment_usage.columns.distance (new)
+- st.dlg.equipment_usage.columns.duration (new)
+- st.dlg.equipment_usage.columns.first_usage (new)
+- st.dlg.equipment_usage.columns.last_usage (new)
+- st.dlg.equipment_usage.empty (new)
+
 SportsTracker 7.6.1:
 
 - st.main.info.update_available (new)

--- a/sportstracker/docs/README.txt
+++ b/sportstracker/docs/README.txt
@@ -243,6 +243,11 @@ distance per sport subtype or equipment for a selected sport type.
 And finally it can also display the history of your body weight in the 
 selected time range.
 
+The Equipment Usage dialog can be used for showing usage statistics of each
+equipment for a selected sport type. The usage contains the total distance,
+duration and dates of first and last usage. So it's very easy to identify
+worn and outdated equipment or just to get interesting usage details.
+
 Whenever SportsTracker displays multiple exercises, which are using sport types
 with different speed modes, then the preferred speed mode will be used. This
 can be defined in the Preferences Dialog.

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -1,6 +1,13 @@
 SportsTracker-TODO
 ==================
 
+Equipment Usage:
+- see TODOs
+- german translation (also in menubar, check shortcut)
+- Exercise Dialog: add Warning message when user stores an exercise without
+  an selected equipment (if there is one for the current sport type)
+- add to ReadMe, Changelog
+
 macOS Catalina problem:
 - when using a non-hidpi display (e.g. a 24" 1920x1200) the text rendering looks broken
   - the antialiased text in labels, menus and text fields looks like vertical pixel

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -2,7 +2,7 @@ SportsTracker-TODO
 ==================
 
 Equipment Usage:
-- see TODOs
+- manual testing of computed statistics
 - german translation (also in menubar, check shortcut)
 - Exercise Dialog: add Warning message when user stores an exercise without
   an selected equipment (if there is one for the current sport type)

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -1,9 +1,6 @@
 SportsTracker-TODO
 ==================
 
-Exercise Dialog: add Warning message when user stores an exercise without
-  an selected equipment (if there is one for the current sport type)
-
 macOS Catalina problem:
 - when using a non-hidpi display (e.g. a 24" 1920x1200) the text rendering looks broken
   - the antialiased text in labels, menus and text fields looks like vertical pixel

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -2,7 +2,6 @@ SportsTracker-TODO
 ==================
 
 Equipment Usage:
-- manual testing of computed statistics
 - german translation (also in menubar, check shortcut)
 - Exercise Dialog: add Warning message when user stores an exercise without
   an selected equipment (if there is one for the current sport type)

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -1,10 +1,8 @@
 SportsTracker-TODO
 ==================
 
-Equipment Usage:
-- Exercise Dialog: add Warning message when user stores an exercise without
+Exercise Dialog: add Warning message when user stores an exercise without
   an selected equipment (if there is one for the current sport type)
-- add to ReadMe, Changelog
 
 macOS Catalina problem:
 - when using a non-hidpi display (e.g. a 24" 1920x1200) the text rendering looks broken

--- a/sportstracker/docs/TODO.txt
+++ b/sportstracker/docs/TODO.txt
@@ -2,7 +2,6 @@ SportsTracker-TODO
 ==================
 
 Equipment Usage:
-- german translation (also in menubar, check shortcut)
 - Exercise Dialog: add Warning message when user stores an exercise without
   an selected equipment (if there is one for the current sport type)
 - add to ReadMe, Changelog

--- a/sportstracker/src/main/java/de/saring/sportstracker/gui/STController.java
+++ b/sportstracker/src/main/java/de/saring/sportstracker/gui/STController.java
@@ -107,6 +107,11 @@ public interface STController extends EntryViewEventHandler {
     void onOverviewDiagram(ActionEvent event);
 
     /**
+     * Event handler for action "Equipment Usage".
+     */
+    void onEquipmentUsage(ActionEvent event);
+
+    /**
      * Event handler for action "Project Website".
      */
     void onWebsite(ActionEvent event);

--- a/sportstracker/src/main/java/de/saring/sportstracker/gui/STControllerImpl.java
+++ b/sportstracker/src/main/java/de/saring/sportstracker/gui/STControllerImpl.java
@@ -475,6 +475,15 @@ public class STControllerImpl implements STController, EntryViewEventHandler {
     }
 
     @Override
+    public void onEquipmentUsage(final ActionEvent event) {
+        if (!checkForExistingExercises()) {
+            return;
+        }
+
+        dialogProvider.prEquipmentUsageDialogController.get().show(context.getPrimaryStage());
+    }
+
+    @Override
     public void onWebsite(final ActionEvent event) {
         context.getHostServices().showDocument(URL_PROJECT_WEBSITE);
     }

--- a/sportstracker/src/main/java/de/saring/sportstracker/gui/dialogs/DialogProvider.java
+++ b/sportstracker/src/main/java/de/saring/sportstracker/gui/dialogs/DialogProvider.java
@@ -35,10 +35,13 @@ public class DialogProvider {
     
     /** Provider for the StatisticDialogController */
     public Provider<StatisticDialogController> prStatisticDialogController;
-    
+
     /** Provider for the OverviewDialogController */
     public Provider<OverviewDialogController> prOverviewDialogController;
-    
+
+    /** Provider for the EquipmentUsageDialogController */
+    public Provider<EquipmentUsageDialogController> prEquipmentUsageDialogController;
+
     /** Provider for the PreferencesDialogController */
     public Provider<PreferencesDialogController> prPreferencesDialogController;
     
@@ -59,6 +62,7 @@ public class DialogProvider {
      * @param prSportTypeListDialogController provider for the SportTypeListDialogController
      * @param prStatisticDialogController provider for the StatisticDialogController
      * @param prOverviewDialogController provider for the OverviewDialogController
+     * @param prEquipmentUsageDialogController provider for the EquipmentUsageDialogController
      * @param prPreferencesDialogController provider for the PreferencesDialogController
      * @param prFilterDialogController provider for the FilterDialogController
      * @param prAboutDialogController provider for the AboutDialogController
@@ -72,6 +76,7 @@ public class DialogProvider {
                           Provider<SportTypeListDialogController> prSportTypeListDialogController,
                           Provider<StatisticDialogController> prStatisticDialogController,
                           Provider<OverviewDialogController> prOverviewDialogController,
+                          Provider<EquipmentUsageDialogController> prEquipmentUsageDialogController,
                           Provider<PreferencesDialogController> prPreferencesDialogController,
                           Provider<FilterDialogController> prFilterDialogController,
                           Provider<AboutDialogController> prAboutDialogController) {
@@ -83,6 +88,7 @@ public class DialogProvider {
         this.prSportTypeListDialogController = prSportTypeListDialogController;
         this.prStatisticDialogController = prStatisticDialogController;
         this.prOverviewDialogController = prOverviewDialogController;
+        this.prEquipmentUsageDialogController = prEquipmentUsageDialogController;
         this.prPreferencesDialogController = prPreferencesDialogController;
         this.prFilterDialogController = prFilterDialogController;
         this.prAboutDialogController = prAboutDialogController;

--- a/sportstracker/src/main/java/de/saring/sportstracker/gui/views/listviews/AbstractListViewController.java
+++ b/sportstracker/src/main/java/de/saring/sportstracker/gui/views/listviews/AbstractListViewController.java
@@ -145,27 +145,27 @@ public abstract class AbstractListViewController<T extends IdObject> extends Abs
             final TableRow<T> tableRow = new TableRow<>();
 
             // update table row color when the item value, the selection or the focus has been changed
-                tableRow.itemProperty().addListener((observable, oldValue, newValue) -> updateTableRowColor(tableRow));
-                tableRow.selectedProperty().addListener( //
-                        (observable, oldValue, newValue) -> updateTableRowColor(tableRow));
-                getTableView().focusedProperty().addListener( //
-                        (observable, oldValue, newValue) -> updateTableRowColor(tableRow));
+            tableRow.itemProperty().addListener((observable, oldValue, newValue) -> updateTableRowColor(tableRow));
+            tableRow.selectedProperty().addListener( //
+                    (observable, oldValue, newValue) -> updateTableRowColor(tableRow));
+            getTableView().focusedProperty().addListener( //
+                    (observable, oldValue, newValue) -> updateTableRowColor(tableRow));
 
-                // bind context menu to row, but only when the row is not empty
-                tableRow.contextMenuProperty().bind( //
-                        Bindings.when(tableRow.emptyProperty()) //
-                                .then((ContextMenu) null) //
-                                .otherwise(contextMenu));
+            // bind context menu to row, but only when the row is not empty
+            tableRow.contextMenuProperty().bind( //
+                    Bindings.when(tableRow.emptyProperty()) //
+                            .then((ContextMenu) null) //
+                            .otherwise(contextMenu));
 
-                // add listener for double clicks for editing the selected entry (ignore in empty rows)
-                tableRow.setOnMouseClicked(event -> {
-                    if (event.getClickCount() > 1 && getSelectedEntryCount() == 1 && !tableRow.isEmpty()) {
-                        getEventHandler().onEditEntry(null);
-                    }
-                });
-
-                return tableRow;
+            // add listener for double clicks for editing the selected entry (ignore in empty rows)
+            tableRow.setOnMouseClicked(event -> {
+                if (event.getClickCount() > 1 && getSelectedEntryCount() == 1 && !tableRow.isEmpty()) {
+                    getEventHandler().onEditEntry(null);
+                }
             });
+
+            return tableRow;
+        });
     }
 
     /**

--- a/sportstracker/src/main/java/de/saring/sportstracker/gui/views/listviews/ExerciseListViewController.java
+++ b/sportstracker/src/main/java/de/saring/sportstracker/gui/views/listviews/ExerciseListViewController.java
@@ -8,7 +8,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import de.saring.sportstracker.core.STOptions;
-import de.saring.sportstracker.data.Equipment;
 import de.saring.sportstracker.data.Exercise;
 import de.saring.sportstracker.data.Exercise.IntensityType;
 import de.saring.sportstracker.data.SportSubType;
@@ -140,10 +139,6 @@ public class ExerciseListViewController extends AbstractListViewController<Exerc
         tcAscent.setCellValueFactory(new PropertyValueFactory<>("ascent"));
         tcDescent.setCellValueFactory(new PropertyValueFactory<>("descent"));
         tcEnergy.setCellValueFactory(new PropertyValueFactory<>("calories"));
-        tcEquipment.setCellValueFactory(cellData -> {
-            final Equipment equipment = cellData.getValue().getEquipment();
-            return new SimpleObjectProperty<>(equipment == null ? null : equipment.getName());
-        });
         tcEquipment.setCellValueFactory(cellData -> new SimpleObjectProperty<>( //
                 cellData.getValue().getEquipment() == null ? null : cellData.getValue().getEquipment().getName()));
         tcComment.setCellValueFactory(cellData -> new SimpleObjectProperty<>( //

--- a/sportstracker/src/main/kotlin/de/saring/sportstracker/data/statistic/EquipmentUsageCalculator.kt
+++ b/sportstracker/src/main/kotlin/de/saring/sportstracker/data/statistic/EquipmentUsageCalculator.kt
@@ -6,9 +6,21 @@ import de.saring.sportstracker.data.SportType
 import de.saring.sportstracker.data.SportTypeList
 import java.time.LocalDate
 
-// TODO document, integrate and test
+/**
+ * Calculator for the usage of equipment, grouped by sport types.
+ *
+ * @author Stefan Saring
+ */
 object EquipmentUsageCalculator {
 
+    /**
+     * Calculates the usage of equipment in all exercises. The usage will be calculated for all equipments defined
+     * in the passed sport types, also when it has not been used.
+     *
+     * @param exerciseList list of all Exercises
+     * @param sportTypeList list of all SportTypes
+     * @return map of equipment usages, grouped by sport types
+     */
     fun calculateEquipmentUsage(exerciseList: ExerciseList, sportTypeList: SportTypeList): EquipmentUsages {
 
         val equipmentUsages = createInitialEquipmentUsages(sportTypeList)
@@ -16,20 +28,18 @@ object EquipmentUsageCalculator {
         exerciseList.forEach { exercise ->
             exercise.equipment?.let { equipment ->
 
-                val exerciseDate = exercise.dateTime.toLocalDate()
-
-                // TODO without !! ?
-                val equipmentUsage: EquipmentUsage = equipmentUsages.usages[exercise.sportType]!!.usages[equipment]!!
+                val eqUsagesInSportType = equipmentUsages.sportTypeMap[exercise.sportType] ?: error("Not found for SportType!")
+                val equipmentUsage: EquipmentUsage = eqUsagesInSportType.equipmentMap[equipment] ?: error("Not found for Equipment!")
 
                 equipmentUsage.distance += exercise.distance
                 equipmentUsage.duration += exercise.duration
 
-                // TODO can this be done simpler?
-                equipmentUsage.firstUsage = if (equipmentUsage.firstUsage == null) exerciseDate else {
-                    if (exerciseDate.isBefore(equipmentUsage.firstUsage)) exerciseDate else equipmentUsage.firstUsage
+                val exerciseDate = exercise.dateTime.toLocalDate()
+                if (equipmentUsage.firstUsage == null || exerciseDate.isBefore(equipmentUsage.firstUsage)) {
+                    equipmentUsage.firstUsage = exerciseDate
                 }
-                equipmentUsage.lastUsage = if (equipmentUsage.lastUsage == null) exerciseDate else {
-                    if (exerciseDate.isAfter(equipmentUsage.lastUsage)) exerciseDate else equipmentUsage.lastUsage
+                if (equipmentUsage.lastUsage == null || exerciseDate.isAfter(equipmentUsage.lastUsage)) {
+                    equipmentUsage.lastUsage = exerciseDate
                 }
             }
         }
@@ -46,10 +56,29 @@ object EquipmentUsageCalculator {
     }
 }
 
-class EquipmentUsages(val usages: Map<SportType, EquipmentUsagesInSportType>)
+/**
+ * Container class for all equipment usages.
+ *
+ * @property sportTypeMap map of usages grouped by sport types
+ */
+class EquipmentUsages(val sportTypeMap: Map<SportType, EquipmentUsagesInSportType>)
 
-class EquipmentUsagesInSportType(val usages: Map<Equipment, EquipmentUsage>)
+/**
+ * Container class for the equipment usages in one single sport type.
+ *
+ * @property equipmentMap map of usages grouped by equipments
+ */
+class EquipmentUsagesInSportType(val equipmentMap: Map<Equipment, EquipmentUsage>)
 
+/**
+ * Container class for the usage of one single equipment.
+ *
+ * @property equipment the used equipment
+ * @property distance: total usage distance in kilometers
+ * @property duration total usage duration in seconds
+ * @property firstUsage first usage date of the equipment (null when unused)
+ * @property lastUsage last usage date of the equipment (null when unused)
+ */
 class EquipmentUsage(
         val equipment: Equipment,
         var distance: Double = 0.0,

--- a/sportstracker/src/main/kotlin/de/saring/sportstracker/data/statistic/EquipmentUsageCalculator.kt
+++ b/sportstracker/src/main/kotlin/de/saring/sportstracker/data/statistic/EquipmentUsageCalculator.kt
@@ -28,8 +28,10 @@ object EquipmentUsageCalculator {
         exerciseList.forEach { exercise ->
             exercise.equipment?.let { equipment ->
 
-                val eqUsagesInSportType = equipmentUsages.sportTypeMap[exercise.sportType] ?: error("Not found for SportType!")
-                val equipmentUsage: EquipmentUsage = eqUsagesInSportType.equipmentMap[equipment] ?: error("Not found for Equipment!")
+                val eqUsagesInSportType = equipmentUsages.sportTypeMap[exercise.sportType]
+                        ?: error("Not found for SportType with ID ${exercise.sportType.id}!")
+                val equipmentUsage: EquipmentUsage = eqUsagesInSportType.equipmentMap[equipment]
+                        ?: error("Not found for Equipment with ID ${equipment.id}!")
 
                 equipmentUsage.distance += exercise.distance
                 equipmentUsage.duration += exercise.duration

--- a/sportstracker/src/main/kotlin/de/saring/sportstracker/data/statistic/EquipmentUsageCalculator.kt
+++ b/sportstracker/src/main/kotlin/de/saring/sportstracker/data/statistic/EquipmentUsageCalculator.kt
@@ -1,0 +1,58 @@
+package de.saring.sportstracker.data.statistic
+
+import de.saring.sportstracker.data.Equipment
+import de.saring.sportstracker.data.ExerciseList
+import de.saring.sportstracker.data.SportType
+import de.saring.sportstracker.data.SportTypeList
+import java.time.LocalDate
+
+// TODO document, integrate and test
+object EquipmentUsageCalculator {
+
+    fun calculateEquipmentUsage(exerciseList: ExerciseList, sportTypeList: SportTypeList): EquipmentUsages {
+
+        val equipmentUsages = createInitialEquipmentUsages(sportTypeList)
+
+        exerciseList.forEach { exercise ->
+            exercise.equipment?.let { equipment ->
+
+                val exerciseDate = exercise.dateTime.toLocalDate()
+
+                // TODO without !! ?
+                val equipmentUsage: EquipmentUsage = equipmentUsages.usages[exercise.sportType]!!.usages[equipment]!!
+
+                equipmentUsage.distance += exercise.distance
+                equipmentUsage.duration += exercise.duration
+
+                // TODO can this be done simpler?
+                equipmentUsage.firstUsage = if (equipmentUsage.firstUsage == null) exerciseDate else {
+                    if (exerciseDate.isBefore(equipmentUsage.firstUsage)) exerciseDate else equipmentUsage.firstUsage
+                }
+                equipmentUsage.lastUsage = if (equipmentUsage.lastUsage == null) exerciseDate else {
+                    if (exerciseDate.isAfter(equipmentUsage.lastUsage)) exerciseDate else equipmentUsage.lastUsage
+                }
+            }
+        }
+
+        return equipmentUsages
+    }
+
+    private fun createInitialEquipmentUsages(sportTypes: SportTypeList): EquipmentUsages {
+        return EquipmentUsages(sportTypes.map { sportType ->
+            sportType to EquipmentUsagesInSportType(sportType.equipmentList.map { equipment ->
+                equipment to EquipmentUsage(equipment)
+            }.toMap())
+        }.toMap())
+    }
+}
+
+class EquipmentUsages(val usages: Map<SportType, EquipmentUsagesInSportType>)
+
+class EquipmentUsagesInSportType(val usages: Map<Equipment, EquipmentUsage>)
+
+class EquipmentUsage(
+        val equipment: Equipment,
+        var distance: Double = 0.0,
+        var duration: Long = 0,
+        var firstUsage: LocalDate? = null,
+        var lastUsage: LocalDate? = null)

--- a/sportstracker/src/main/kotlin/de/saring/sportstracker/gui/dialogs/EquipmentUsageDialogController.kt
+++ b/sportstracker/src/main/kotlin/de/saring/sportstracker/gui/dialogs/EquipmentUsageDialogController.kt
@@ -1,0 +1,46 @@
+package de.saring.sportstracker.gui.dialogs
+
+import de.saring.sportstracker.data.SportType
+import de.saring.sportstracker.gui.STContext
+import de.saring.sportstracker.gui.STDocument
+import de.saring.util.gui.javafx.NameableStringConverter
+import javafx.fxml.FXML
+import javafx.scene.control.ChoiceBox
+import javafx.stage.Window
+
+/**
+ * Controller (MVC) class of the Equipment Usage dialog (statistics) of the SportsTracker application.
+ *
+ * @constructor constructor for dependency injection
+ * @param context the SportsTracker UI context
+ * @property document the SportsTracker document / model
+ *
+ * @author Stefan Saring
+ */
+class EquipmentUsageDialogController(
+        context: STContext,
+        private val document: STDocument) : AbstractDialogController(context) {
+
+    @FXML
+    private lateinit var cbSportType: ChoiceBox<SportType>
+
+    /**
+     * Displays the Equipment Usage dialog.
+     *
+     * @param parent parent window of the dialog
+     */
+    fun show(parent: Window) {
+        showInfoDialog("/fxml/dialogs/EquipmentUsageDialog.fxml", parent,
+                context.resources.getString("st.dlg.equipment_usage.title"))
+    }
+
+    override fun setupDialogControls() {
+
+        // fill sport type choice box
+        cbSportType.converter = NameableStringConverter()
+        document.sportTypeList.forEach { cbSportType.items.add(it) }
+        cbSportType.value = document.sportTypeList.first()
+
+        // TODO
+    }
+}

--- a/sportstracker/src/main/kotlin/de/saring/sportstracker/gui/dialogs/EquipmentUsageDialogController.kt
+++ b/sportstracker/src/main/kotlin/de/saring/sportstracker/gui/dialogs/EquipmentUsageDialogController.kt
@@ -15,6 +15,7 @@ import javafx.event.ActionEvent
 import javafx.fxml.FXML
 import javafx.scene.control.ChoiceBox
 import javafx.scene.control.TableColumn
+import javafx.scene.control.TableRow
 import javafx.scene.control.TableView
 import javafx.scene.control.cell.PropertyValueFactory
 import javafx.stage.Window
@@ -102,8 +103,39 @@ class EquipmentUsageDialogController(
         tcFirstUsage.cellFactory = LocalDateCellFactory<EquipmentUsage>()
         tcLastUsage.cellFactory = LocalDateCellFactory<EquipmentUsage>()
 
+        setupTableRowFactory()
+
         // sort rows by the equipment name column initially
         tvEquipmentUsages.sortOrder.add(tcName)
+    }
+
+    /**
+     * Initializes the table rows coloring: equipment which is not in use anymore has to be shown in a gray color.
+     */
+    private fun setupTableRowFactory() {
+        tvEquipmentUsages.rowFactory = Callback {
+            val tableRow = TableRow<EquipmentUsage?>()
+
+            // update table row color whenever the item value, the selection or the focus has been changed
+            tableRow.itemProperty().addListener { _ -> updateTableRowColor(tableRow) }
+            tableRow.selectedProperty().addListener { _ -> updateTableRowColor(tableRow) }
+            tvEquipmentUsages.focusedProperty().addListener { _ -> updateTableRowColor(tableRow) }
+            tableRow
+        }
+    }
+
+    private fun updateTableRowColor(tableRow: TableRow<EquipmentUsage?>) {
+        // display rows for equipment not in use in gray color, otherwise in default color
+        // => use white when the row is selected and the table is focused (default)
+        // => tableRow.setTextFill() does not work here, color must be set by a CSS style
+        tableRow.item?.let {equipmentUsage ->
+
+            val useDefaultColor = tableRow.isSelected && tvEquipmentUsages.isFocused
+            val color = if (useDefaultColor) ROW_COLOR_SELECTED_FOCUSED else {
+                if (equipmentUsage.equipment.isNotInUse) ROW_COLOR_NOT_IN_USE else ROW_COLOR_DEFAULT
+            }
+            tableRow.style = "-fx-text-background-color: $color;"
+        }
     }
 
     /**
@@ -121,5 +153,11 @@ class EquipmentUsageDialogController(
     private fun getDateTimeForDate(date: LocalDate?): LocalDateTime? {
         return if (date == null) return null
         else LocalDateTime.of(date, LocalTime.of(0, 0))
+    }
+
+    companion object {
+        const val ROW_COLOR_SELECTED_FOCUSED = "#ffffff"
+        const val ROW_COLOR_DEFAULT = "#333333"
+        const val ROW_COLOR_NOT_IN_USE = "#909090"
     }
 }

--- a/sportstracker/src/main/kotlin/de/saring/sportstracker/gui/dialogs/EquipmentUsageDialogController.kt
+++ b/sportstracker/src/main/kotlin/de/saring/sportstracker/gui/dialogs/EquipmentUsageDialogController.kt
@@ -1,6 +1,8 @@
 package de.saring.sportstracker.gui.dialogs
 
 import de.saring.sportstracker.data.SportType
+import de.saring.sportstracker.data.statistic.EquipmentUsageCalculator
+import de.saring.sportstracker.data.statistic.EquipmentUsages
 import de.saring.sportstracker.gui.STContext
 import de.saring.sportstracker.gui.STDocument
 import de.saring.util.gui.javafx.NameableStringConverter
@@ -24,6 +26,8 @@ class EquipmentUsageDialogController(
     @FXML
     private lateinit var cbSportType: ChoiceBox<SportType>
 
+    private lateinit var equipmentUsages: EquipmentUsages
+
     /**
      * Displays the Equipment Usage dialog.
      *
@@ -36,11 +40,11 @@ class EquipmentUsageDialogController(
 
     override fun setupDialogControls() {
 
+        equipmentUsages = EquipmentUsageCalculator.calculateEquipmentUsage(document.exerciseList, document.sportTypeList)
+
         // fill sport type choice box
         cbSportType.converter = NameableStringConverter()
         document.sportTypeList.forEach { cbSportType.items.add(it) }
         cbSportType.value = document.sportTypeList.first()
-
-        // TODO
     }
 }

--- a/sportstracker/src/main/kotlin/de/saring/sportstracker/gui/dialogs/EquipmentUsageDialogController.kt
+++ b/sportstracker/src/main/kotlin/de/saring/sportstracker/gui/dialogs/EquipmentUsageDialogController.kt
@@ -11,7 +11,6 @@ import de.saring.util.gui.javafx.LocalDateCellFactory
 import de.saring.util.gui.javafx.NameableStringConverter
 import de.saring.util.unitcalc.TimeUtils
 import javafx.beans.property.SimpleObjectProperty
-import javafx.collections.FXCollections
 import javafx.event.ActionEvent
 import javafx.fxml.FXML
 import javafx.scene.control.ChoiceBox
@@ -55,9 +54,6 @@ class EquipmentUsageDialogController(
     private lateinit var tcLastUsage: TableColumn<EquipmentUsage, LocalDateTime>
 
     private lateinit var equipmentUsages: EquipmentUsages
-
-    // TODO dialog width is too small when scrollbars are shown
-    // TODO keep sort order when sport type selection changes
 
     /**
      * Displays the Equipment Usage dialog.
@@ -118,7 +114,8 @@ class EquipmentUsageDialogController(
         val equipmentUsage = this.equipmentUsages.sportTypeMap[selectedSportType]
                 ?: error("Not found for SportType with ID ${selectedSportType.id}!")
 
-        tvEquipmentUsages.items = FXCollections.observableArrayList(equipmentUsage.equipmentMap.values)
+        tvEquipmentUsages.items.setAll(equipmentUsage.equipmentMap.values)
+        tvEquipmentUsages.sort()
     }
 
     private fun getDateTimeForDate(date: LocalDate?): LocalDateTime? {

--- a/sportstracker/src/main/resources/fxml/SportsTracker.fxml
+++ b/sportstracker/src/main/resources/fxml/SportsTracker.fxml
@@ -82,6 +82,7 @@
                                 <MenuItem mnemonicParsing="true" onAction="#onSportTypeEditor" styleClass="menuBarItem" text="%st.view.sporttype_editor.Action.text"/>
                                 <MenuItem mnemonicParsing="true" onAction="#onStatistics" styleClass="menuBarItem" text="%st.view.statistics.Action.text"/>
                                 <MenuItem mnemonicParsing="true" onAction="#onOverviewDiagram" styleClass="menuBarItem" text="%st.view.overview_diagram.Action.text"/>
+                                <MenuItem mnemonicParsing="true" onAction="#onEquipmentUsage" styleClass="menuBarItem" text="%st.view.equipment_usage.Action.text"/>
                             </items>
                         </Menu>
                         <Menu mnemonicParsing="true" text="%st.view.help.text">

--- a/sportstracker/src/main/resources/fxml/dialogs/EquipmentUsageDialog.fxml
+++ b/sportstracker/src/main/resources/fxml/dialogs/EquipmentUsageDialog.fxml
@@ -15,13 +15,15 @@
             <ChoiceBox fx:id="cbSportType" minWidth="160.0" />
          </children>
       </HBox>
-        <TableView fx:id="tvEquipmentUsages" prefHeight="320.0" VBox.vgrow="ALWAYS">
+        <!-- set preferred table width to width of all columns + 20 pixels
+             => so there's enough space for the vertical scrollbar without showing the horizontal scrollbar -->
+        <TableView fx:id="tvEquipmentUsages" prefWidth="640.0" prefHeight="320.0" VBox.vgrow="ALWAYS">
             <columns>
-                <TableColumn fx:id="tcName" prefWidth="200.0" text="%st.dlg.equipment_usage.columns.name" />
-                <TableColumn fx:id="tcDistance" prefWidth="90.0" text="%st.dlg.equipment_usage.columns.distance" />
-                <TableColumn fx:id="tcDuration" prefWidth="90.0" text="%st.dlg.equipment_usage.columns.duration" />
-                <TableColumn fx:id="tcFirstUsage" prefWidth="90.0" text="%st.dlg.equipment_usage.columns.first_usage" />
-                <TableColumn fx:id="tcLastUsage" prefWidth="90.0" text="%st.dlg.equipment_usage.columns.last_usage" />
+                <TableColumn fx:id="tcName" prefWidth="220.0" text="%st.dlg.equipment_usage.columns.name" />
+                <TableColumn fx:id="tcDistance" prefWidth="100.0" text="%st.dlg.equipment_usage.columns.distance" />
+                <TableColumn fx:id="tcDuration" prefWidth="100.0" text="%st.dlg.equipment_usage.columns.duration" />
+                <TableColumn fx:id="tcFirstUsage" prefWidth="100.0" text="%st.dlg.equipment_usage.columns.first_usage" />
+                <TableColumn fx:id="tcLastUsage" prefWidth="100.0" text="%st.dlg.equipment_usage.columns.last_usage" />
             </columns>
             <placeholder>
                 <Label text="%st.dlg.equipment_usage.empty" />

--- a/sportstracker/src/main/resources/fxml/dialogs/EquipmentUsageDialog.fxml
+++ b/sportstracker/src/main/resources/fxml/dialogs/EquipmentUsageDialog.fxml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.ChoiceBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TableColumn?>
+<?import javafx.scene.control.TableView?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox spacing="16.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="de.saring.sportstracker.gui.dialogs.EquipmentUsageDialogController">
+    <children>
+      <HBox alignment="CENTER_LEFT" spacing="16.0">
+         <children>
+            <Label text="%st.dlg.equipment_usage.sport_type.text" />
+            <ChoiceBox fx:id="cbSportType" minWidth="160.0" />
+         </children>
+      </HBox>
+        <TableView fx:id="tvEquipmentUsages" prefHeight="320.0" VBox.vgrow="ALWAYS">
+            <columns>
+                <TableColumn fx:id="tcName" prefWidth="200.0" text="%st.dlg.equipment_usage.columns.name" />
+                <TableColumn fx:id="tcDistance" prefWidth="90.0" text="%st.dlg.equipment_usage.columns.distance" />
+                <TableColumn fx:id="tcDuration" prefWidth="90.0" text="%st.dlg.equipment_usage.columns.duration" />
+                <TableColumn fx:id="tcFirstUsage" prefWidth="90.0" text="%st.dlg.equipment_usage.columns.first_usage" />
+                <TableColumn fx:id="tcLastUsage" prefWidth="90.0" text="%st.dlg.equipment_usage.columns.last_usage" />
+            </columns>
+            <placeholder>
+                <Label text="%st.dlg.equipment_usage.empty" />
+            </placeholder>
+        </TableView>
+    </children>
+</VBox>

--- a/sportstracker/src/main/resources/fxml/dialogs/EquipmentUsageDialog.fxml
+++ b/sportstracker/src/main/resources/fxml/dialogs/EquipmentUsageDialog.fxml
@@ -17,13 +17,13 @@
       </HBox>
         <!-- set preferred table width to width of all columns + 20 pixels
              => so there's enough space for the vertical scrollbar without showing the horizontal scrollbar -->
-        <TableView fx:id="tvEquipmentUsages" prefWidth="640.0" prefHeight="320.0" VBox.vgrow="ALWAYS">
+        <TableView fx:id="tvEquipmentUsages" prefWidth="680.0" prefHeight="320.0" VBox.vgrow="ALWAYS">
             <columns>
                 <TableColumn fx:id="tcName" prefWidth="220.0" text="%st.dlg.equipment_usage.columns.name" />
-                <TableColumn fx:id="tcDistance" prefWidth="100.0" text="%st.dlg.equipment_usage.columns.distance" />
-                <TableColumn fx:id="tcDuration" prefWidth="100.0" text="%st.dlg.equipment_usage.columns.duration" />
-                <TableColumn fx:id="tcFirstUsage" prefWidth="100.0" text="%st.dlg.equipment_usage.columns.first_usage" />
-                <TableColumn fx:id="tcLastUsage" prefWidth="100.0" text="%st.dlg.equipment_usage.columns.last_usage" />
+                <TableColumn fx:id="tcDistance" prefWidth="110.0" text="%st.dlg.equipment_usage.columns.distance" />
+                <TableColumn fx:id="tcDuration" prefWidth="110.0" text="%st.dlg.equipment_usage.columns.duration" />
+                <TableColumn fx:id="tcFirstUsage" prefWidth="110.0" text="%st.dlg.equipment_usage.columns.first_usage" />
+                <TableColumn fx:id="tcLastUsage" prefWidth="110.0" text="%st.dlg.equipment_usage.columns.last_usage" />
             </columns>
             <placeholder>
                 <Label text="%st.dlg.equipment_usage.empty" />

--- a/sportstracker/src/main/resources/i18n/SportsTracker.properties
+++ b/sportstracker/src/main/resources/i18n/SportsTracker.properties
@@ -4,7 +4,7 @@
 # Version: SportsTracker 7.7.1
 # Last update: 2019/12/28
 #
-# (C) 2019, Stefan Saring
+# (C) 2020, Stefan Saring
 #####################################################################
 
 application.title=SportsTracker
@@ -468,7 +468,7 @@ st.dlg.options.smoothed_charts.text=Show smoothed charts (average filter)
 st.dlg.about.title=About SportsTracker
 st.dlg.about.description.text=A tool for tracking your sport activities and viewing exercise files.\nIt's written for the Java platform and uses the JavaFX toolkit.
 st.dlg.about.license.text=License: GNU General Public License (GPL), Version 2
-st.dlg.about.copyright.text=(C) 2019 Stefan Saring
+st.dlg.about.copyright.text=(C) 2020 Stefan Saring
 st.dlg.about.title.authors=Authors
 st.dlg.about.title.translators=Translators
 st.dlg.about.authors.text=\

--- a/sportstracker/src/main/resources/i18n/SportsTracker.properties
+++ b/sportstracker/src/main/resources/i18n/SportsTracker.properties
@@ -2,7 +2,7 @@
 # SportsTracker resources for english language (default)
 #
 # Version: SportsTracker 7.7.1
-# Last update: 2019/12/28
+# Last update: 2020/01/01
 #
 # (C) 2020, Stefan Saring
 #####################################################################
@@ -288,12 +288,13 @@ st.dlg.exercise.error.ascent=You need to enter a valid ascent!
 st.dlg.exercise.error.descent=You need to enter a valid descent!
 st.dlg.exercise.error.avg_heartrate=You need to enter a valid average heartrate!
 st.dlg.exercise.error.calories=You need to enter a valid amount for calorie consumption!
-st.dlg.exercise.error.import_console=Failed to read or parse HRM file '%s'.\nSee console output for more detailed informations.
+st.dlg.exercise.error.import_console=Failed to read or parse HRM file '%s'.\nSee console output for more detailed information.
 st.dlg.exercise.error.no_sport_type=You need to select a sport type!
 st.dlg.exercise.error.no_sport_subtype=You need to select a sport subtype!
 st.dlg.exercise.error.no_intensity=You need to select an intensity!
 st.dlg.exercise.error.no_sport_and_subtype=You need to select a sport type and subtype first!
 st.dlg.exercise.error.no_previous_exercise=Can't find a comment in a previous similar exercise.
+st.dlg.exercise.info.no_equipment=Do you want to store without an equipment selection?
 
 st.dlg.hrm_file_open.title=Select HRM File
 st.dlg.hrm_file_open.filter_all_files=All files

--- a/sportstracker/src/main/resources/i18n/SportsTracker.properties
+++ b/sportstracker/src/main/resources/i18n/SportsTracker.properties
@@ -2,7 +2,7 @@
 # SportsTracker resources for english language (default)
 #
 # Version: SportsTracker 7.7.1
-# Last update: 2019/07/13
+# Last update: 2019/12/28
 #
 # (C) 2019, Stefan Saring
 #####################################################################
@@ -96,6 +96,8 @@ st.view.statistics.Action.text=_Statistics
 st.view.statistics.Action.shortDescription=Statistics
 st.view.overview_diagram.Action.text=_Overview Diagram
 st.view.overview_diagram.Action.shortDescription=Overview Diagram
+st.view.equipment_usage.Action.text=Equipment _Usage
+st.view.equipment_usage.Action.shortDescription=Equipment Usage Statistics
 
 st.view.help.text=_Help
 st.view.website.Action.text=Project _Website
@@ -416,6 +418,16 @@ st.dlg.overview.value_type.equipment_distance=Distance per equipment (%s)
 st.dlg.overview.value_type.weight=Weight (%s)
 st.dlg.overview.graph.all_types=all types
 st.dlg.overview.equipment.not_specified=not specified
+
+# Equipment Usage dialog
+st.dlg.equipment_usage.title=Equipment Usage
+st.dlg.equipment_usage.sport_type.text=Sport type:
+st.dlg.equipment_usage.columns.name=Name
+st.dlg.equipment_usage.columns.distance=Distance
+st.dlg.equipment_usage.columns.duration=Duration
+st.dlg.equipment_usage.columns.first_usage=First Usage
+st.dlg.equipment_usage.columns.last_usage=Last Usage
+st.dlg.equipment_usage.empty=No equipment available
 
 # Options dialog
 st.dlg.options.title=SportsTracker Preferences

--- a/sportstracker/src/main/resources/i18n/SportsTracker_de.properties
+++ b/sportstracker/src/main/resources/i18n/SportsTracker_de.properties
@@ -2,7 +2,7 @@
 # SportsTracker resources for german language
 #
 # Version: SportsTracker 7.7.1
-# Last update: 2019/12/31
+# Last update: 2020/01/01
 #
 # (C) 2020, Stefan Saring
 # Translated by Stefan Saring <projects@saring.de>
@@ -293,6 +293,7 @@ st.dlg.exercise.error.no_sport_subtype=Sie müssen eine Sportunterart wählen!
 st.dlg.exercise.error.no_intensity=Sie müssen eine Intensität wählen!
 st.dlg.exercise.error.no_sport_and_subtype=Sie müssen zuerst eine Sportart und Sportunterart wählen!
 st.dlg.exercise.error.no_previous_exercise=Es wurde keine Bemerkung in einer vorigen ähnlichen Einheit gefunden.
+st.dlg.exercise.info.no_equipment=Möchten Sie ohne der Auswahl einer Ausrüstung speichern?
 
 st.dlg.hrm_file_open.title=HRM Datei wählen
 st.dlg.hrm_file_open.filter_all_files=Alle Dateien

--- a/sportstracker/src/main/resources/i18n/SportsTracker_de.properties
+++ b/sportstracker/src/main/resources/i18n/SportsTracker_de.properties
@@ -4,7 +4,7 @@
 # Version: SportsTracker 7.7.1
 # Last update: 2019/07/13
 #
-# (C) 2019, Stefan Saring
+# (C) 2020, Stefan Saring
 # Translated by Stefan Saring <projects@saring.de>
 #####################################################################
 

--- a/sportstracker/src/main/resources/i18n/SportsTracker_de.properties
+++ b/sportstracker/src/main/resources/i18n/SportsTracker_de.properties
@@ -2,7 +2,7 @@
 # SportsTracker resources for german language
 #
 # Version: SportsTracker 7.7.1
-# Last update: 2019/07/13
+# Last update: 2019/12/31
 #
 # (C) 2020, Stefan Saring
 # Translated by Stefan Saring <projects@saring.de>
@@ -94,6 +94,8 @@ st.view.statistics.Action.text=_Statistik
 st.view.statistics.Action.shortDescription=Statistik
 st.view.overview_diagram.Action.text=Übersichts_diagramm
 st.view.overview_diagram.Action.shortDescription=Übersichtsdiagramm
+st.view.equipment_usage.Action.text=Nutzung der _Ausrüstung
+st.view.equipment_usage.Action.shortDescription=Nutzung der Ausrüstung
 
 st.view.help.text=_Hilfe
 st.view.website.Action.text=_Webseite des Projekts
@@ -415,6 +417,16 @@ st.dlg.overview.value_type.equipment_distance=Strecke pro Ausrüstung (%s)
 st.dlg.overview.value_type.weight=Gewicht (%s)
 st.dlg.overview.graph.all_types=alle Arten
 st.dlg.overview.equipment.not_specified=ohne Angabe
+
+# Equipment Usage dialog
+st.dlg.equipment_usage.title=Nutzung der Ausrüstung
+st.dlg.equipment_usage.sport_type.text=Sportart:
+st.dlg.equipment_usage.columns.name=Name
+st.dlg.equipment_usage.columns.distance=Strecke
+st.dlg.equipment_usage.columns.duration=Dauer
+st.dlg.equipment_usage.columns.first_usage=Erste Nutzung
+st.dlg.equipment_usage.columns.last_usage=Letzte Nutzung
+st.dlg.equipment_usage.empty=Keine Ausrüstung vorhanden
 
 # Options dialog
 st.dlg.options.title=SportsTracker Einstellungen

--- a/sportstracker/src/test/kotlin/de/saring/sportstracker/data/statistic/EquipmentUsageCalculatorTest.kt
+++ b/sportstracker/src/test/kotlin/de/saring/sportstracker/data/statistic/EquipmentUsageCalculatorTest.kt
@@ -1,0 +1,190 @@
+package de.saring.sportstracker.data.statistic
+
+import de.saring.sportstracker.data.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+/**
+ * This class contains all unit tests for the [EquipmentUsageCalculator] class.
+ *
+ * @author Stefan Saring
+ */
+class EquipmentUsageCalculatorTest {
+
+    private val eqRoadBike = Equipment(1).apply {
+        setName("Road bike")
+    }
+    private val eqMTB = Equipment(2).apply {
+        setName("MTB")
+    }
+
+    private val stCycling = SportType(1).apply {
+        setName("Cycling")
+        equipmentList.set(eqRoadBike)
+        equipmentList.set(eqMTB)
+    }
+
+    private val eqRoadShoes = Equipment(1).apply {
+        setName("Road shows")
+    }
+    private val eqTrailShoes = Equipment(2).apply {
+        setName("Trail shoes")
+    }
+
+    private val stRunning = SportType(2).apply {
+        setName("Running")
+        equipmentList.set(eqRoadShoes)
+        equipmentList.set(eqTrailShoes)
+    }
+
+    private val stSwimming = SportType(3).apply {
+        setName("Swimming")
+    }
+
+    private val sportTypeList = SportTypeList().apply {
+        set(stCycling)
+        set(stRunning)
+        set(stSwimming)
+    }
+
+    /**
+     * Tests the calculation: no exercises are available, so the calculated usage has to be empty for all equipment
+     * entries.
+     */
+    @Test
+    fun testStatisticCalculatorNoExercises() {
+
+        // prepare
+        val exerciseList = ExerciseList()
+
+        // test
+        val usages = EquipmentUsageCalculator.calculateEquipmentUsage(exerciseList, this.sportTypeList)
+
+        // verify
+        assertEquals(3, usages.sportTypeMap.size)
+
+        // check cycling usage
+        val euCycling = usages.sportTypeMap[stCycling]
+        assertEquals(2, euCycling!!.equipmentMap.size)
+        val euRoadBike = euCycling!!.equipmentMap[eqRoadBike]
+        assertUsage(euRoadBike!!, eqRoadBike, 0.0, 0, null, null)
+        val euMTB = euCycling!!.equipmentMap[eqMTB]
+        assertUsage(euMTB!!, eqMTB,0.0, 0, null, null)
+
+        // check running usage
+        val euRunning = usages.sportTypeMap[stRunning]
+        assertEquals(2, euRunning!!.equipmentMap.size)
+        val euRoadShoes = euRunning!!.equipmentMap[eqRoadShoes]
+        assertUsage(euRoadShoes!!, eqRoadShoes, 0.0, 0, null, null)
+        val euTrailShoes = euRunning!!.equipmentMap[eqTrailShoes]
+        assertUsage(euTrailShoes!!, eqTrailShoes,0.0, 0, null, null)
+
+        // check swimming usage
+        val euSwimming = usages.sportTypeMap[stSwimming]
+        assertTrue(euSwimming!!.equipmentMap.isEmpty())
+    }
+
+    /**
+     * Tests the calculation: there are exercises with equipment usage available, so the calculated usage has to be
+     * valid.
+     */
+    @Test
+    fun testStatisticCalculatorWithExercises() {
+
+        // prepare
+        val exerciseList = ExerciseList().apply {
+
+            // cycling exercises (2x Road Bike, 1x MTB)
+            set(Exercise(0).apply {
+                dateTime = LocalDateTime.of(2019, 5, 15, 14, 30, 0)
+                distance = 40.0f
+                duration = (1.5 * 3600).toInt()
+                sportType = stCycling
+                equipment = eqRoadBike
+            })
+            set(Exercise(1).apply {
+                dateTime = LocalDateTime.of(2019, 3, 20, 14, 30, 0)
+                distance = 25.0f
+                duration = (1 * 3600).toInt()
+                sportType = stCycling
+                equipment = eqRoadBike
+            })
+            set(Exercise(2).apply {
+                dateTime = LocalDateTime.of(2019, 7, 18, 14, 30, 0)
+                distance = 44.0f
+                duration = (2 * 3600).toInt()
+                sportType = stCycling
+                equipment = eqMTB
+            })
+
+            // running exercises (2x Trail Shoes, 1x without equipment)
+            set(Exercise(10).apply {
+                dateTime = LocalDateTime.of(2019, 7, 15, 14, 30, 0)
+                distance = 13.5f
+                duration = (1.2 * 3600).toInt()
+                sportType = stRunning
+                equipment = eqTrailShoes
+            })
+            set(Exercise(11).apply {
+                dateTime = LocalDateTime.of(2019, 6, 20, 14, 30, 0)
+                distance = 15.5f
+                duration = (1.5 * 3600).toInt()
+                sportType = stRunning
+                equipment = eqTrailShoes
+            })
+            set(Exercise(12).apply {
+                dateTime = LocalDateTime.of(2019, 10, 18, 14, 30, 0)
+                distance = 20.0f
+                duration = (1.8 * 3600).toInt()
+                sportType = stRunning
+                equipment = null
+            })
+        }
+
+        // test
+        val usages = EquipmentUsageCalculator.calculateEquipmentUsage(exerciseList, this.sportTypeList)
+
+        // verify
+        assertEquals(3, usages.sportTypeMap.size)
+
+        // check cycling usage
+        val euCycling = usages.sportTypeMap[stCycling]
+        assertEquals(2, euCycling!!.equipmentMap.size)
+        val euRoadBike = euCycling!!.equipmentMap[eqRoadBike]
+        assertUsage(euRoadBike!!, eqRoadBike, 65.0, (2.5 * 3600).toLong(),
+                LocalDate.of(2019, 3, 20),
+                LocalDate.of(2019, 5, 15))
+        val euMTB = euCycling!!.equipmentMap[eqMTB]
+        assertUsage(euMTB!!, eqMTB, 44.0, (2 * 3600).toLong(),
+                LocalDate.of(2019, 7, 18),
+                LocalDate.of(2019, 7, 18))
+
+        // check running usage
+        val euRunning = usages.sportTypeMap[stRunning]
+        assertEquals(2, euRunning!!.equipmentMap.size)
+        val euRoadShoes = euRunning!!.equipmentMap[eqRoadShoes]
+        assertUsage(euRoadShoes!!, eqRoadShoes, 0.0, 0, null, null)
+        val euTrailShoes = euRunning!!.equipmentMap[eqTrailShoes]
+        assertUsage(euTrailShoes!!, eqTrailShoes, 29.0, (2.7 * 3600).toLong(),
+                LocalDate.of(2019, 6, 20),
+                LocalDate.of(2019, 7, 15))
+
+        // check swimming usage
+        val euSwimming = usages.sportTypeMap[stSwimming]
+        assertTrue(euSwimming!!.equipmentMap.isEmpty())
+    }
+
+    private fun assertUsage(equipmentUsage: EquipmentUsage, expectedEquipment: Equipment,
+                            expectedDistance: Double, expectedDuration: Long,
+                            expectedFirstUsage: LocalDate?, expectedLastUsage: LocalDate?) {
+
+        assertEquals(expectedEquipment, equipmentUsage.equipment)
+        assertEquals(expectedDistance, equipmentUsage.distance)
+        assertEquals(expectedDuration, equipmentUsage.duration)
+        assertEquals(expectedFirstUsage, equipmentUsage.firstUsage)
+        assertEquals(expectedLastUsage, equipmentUsage.lastUsage)
+    }
+}

--- a/st-packager/package-linux.sh
+++ b/st-packager/package-linux.sh
@@ -29,7 +29,7 @@ $JPACKAGER_DIR/jpackager create-installer \
     --name SportsTracker \
     --version $ST_VERSION \
     --vendor Saring.de \
-    --copyright "(C) 2019 Stefan Saring" \
+    --copyright "(C) 2020 Stefan Saring" \
     --description "Application for tracking your sporting activities." \
     --category "Sports;Utility" \
     --icon ./icons/linux/SportsTracker.png \

--- a/st-packager/package-macos.sh
+++ b/st-packager/package-macos.sh
@@ -29,7 +29,7 @@ $JPACKAGER_DIR/jpackager create-image \
     --name SportsTracker \
     --version $ST_VERSION \
     --vendor Saring.de \
-    --copyright "(C) 2019 Stefan Saring" \
+    --copyright "(C) 2020 Stefan Saring" \
     --description "Application for tracking your sporting activities." \
     --category "Sports;Utility" \
     --icon ./icons/macosx/SportsTracker.icns \

--- a/st-packager/package-windows.bat
+++ b/st-packager/package-windows.bat
@@ -35,7 +35,7 @@ REM use create-image or create-installer depending on the needed package type
     --name SportsTracker ^
     --version %ST_VERSION% ^
     --vendor Saring.de ^
-    --copyright "(C) 2019 Stefan Saring" ^
+    --copyright "(C) 2020 Stefan Saring" ^
     --description "Application for tracking your sporting activities." ^
     --category "Sports;Utility" ^
     --icon ./icons/windows/SportsTracker.ico ^


### PR DESCRIPTION
The added Equipment Usage Dialog displays the usage statistics of all equipment for a selected sport type. So it's easy to get an overview how old the equipment is and whether it has to be replaced (e.g. running shoes).
The dialog can be started from the Tools menu.

The Exercise Dialog now also shows an info message when the user wants to store an exercise with no equipment selection (is often forgotten).